### PR TITLE
[Reusable Component] Breadcrumbs

### DIFF
--- a/client/src/pages/demo/components/index.tsx
+++ b/client/src/pages/demo/components/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-unescaped-entities */
 import React, { Fragment } from 'react';
 import Iframe from '@/src/shared/components/Iframe';
+import Breadcrumbs from '@/src/shared/components/Breadcrumbs';
 import Card from '@/src/shared/components/Card';
 
 const DemoComponent: React.FunctionComponent = () => {
@@ -8,11 +9,25 @@ const DemoComponent: React.FunctionComponent = () => {
     <Fragment>
       <div className="container mx-auto">
         <h1>Components Demo Page</h1>
+
+        <div className="m-4 border">
+          <h2>
+            <b>Jump to</b>
+          </h2>
+          <a href="#iframe">Iframe</a>
+          <br />
+          <a href="#breadcrumbs">Breadcrumbs</a>
+        </div>
         <br />
         <hr className="w-3/4 mx-auto" />
 
         <div className="p-4 border">
-          <Iframe src="https://www.youtube.com/embed/HGl75kurxok" />
+          <h1>Component: Iframe</h1>
+          <br />
+          <Iframe
+            src="https://www.youtube.com/embed/HGl75kurxok"
+            className="border"
+          />
 
           <div className="mt-[5px]">
             <h1>Props: Iframe</h1>
@@ -25,24 +40,61 @@ const DemoComponent: React.FunctionComponent = () => {
                 src = (string)[required] ex.
                 src="https://www.youtube.com/embed/HGl75kurxok"
               </p>
-              <p>title = (string)["auto"] ex. title="Relaxing Music"</p>
+              <p id="iframe">
+                title = (string)["auto"] ex. title="Relaxing Music"
+              </p>
             </div>
           </div>
         </div>
 
         <br />
         <hr className="w-3/4 mx-auto" />
-      </div>
 
-      <div className="p-4 border -b border-black" id="card">
-        <Card height='h-30' title='Sample Card'>
-          <main>This is a card component</main>
-        </Card>
-        <div className="mt-[5px]">
-          <h1>Props: Card</h1>
-          <div className="bg-gray-300 p-[5px]">
-            height: string || ex. height=&apos;h-20&apos; <br />
-            title: string || ex. title=&apos;Sample Title&apos; <br />
+        <div className="p-4 border -b border-black" id="card">
+          <Card height="h-30" title="Sample Card">
+            <main>This is a card component</main>
+          </Card>
+          <div className="mt-[5px]">
+            <h1>Props: Card</h1>
+            <div className="bg-gray-300 p-[5px]">
+              height: string || ex. height=&apos;h-20&apos; <br />
+              title: string || ex. title=&apos;Sample Title&apos; <br />
+            </div>
+          </div>
+        </div>
+
+        <br />
+        <hr className="w-3/4 mx-auto" />
+
+        <div className="p-4 border">
+          <h1>Component: Breadcrumbs</h1>
+
+          <br />
+
+          <Breadcrumbs
+            paths={[
+              {
+                text: 'Profile',
+                url: '/profile'
+              },
+              {
+                text: 'User Information',
+                url: '/profile/information'
+              },
+              {
+                text: 'Component Index',
+                url: '/demo/components'
+              }
+            ]}
+          />
+
+          <br />
+
+          <div className="mt-[5px]" id="breadcrumbs">
+            <h1>Props: Breadcrumbs</h1>
+            <div className="bg-gray-300 p-[5px]">
+              <p>path = (array of object) text:string, url: string</p>
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/shared/components/Breadcrumbs/index.tsx
+++ b/client/src/shared/components/Breadcrumbs/index.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable multiline-ternary */
+import { useRouter } from 'next/router';
+import React, { Fragment } from 'react';
+
+interface pathObject {
+  text: string;
+  url: string;
+}
+
+interface BreadcrumbsProps {
+  paths: pathObject[];
+}
+
+const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({
+  paths
+}: BreadcrumbsProps) => {
+  const { asPath } = useRouter();
+
+  const activeClass = (currentURL: string): string => {
+    return asPath !== currentURL
+      ? 'ml-1 text-sm font-medium text-blue-600 hover:text-blue-300 md:ml-2 dark:text-blue-300 dark:hover:text-white'
+      : 'ml-1 text-sm font-medium text-gray-600 hover:text-gray-300 pointer-events-none';
+  };
+
+  return (
+    <div>
+      <nav className="flex" aria-label="Breadcrumb">
+        <ol className="inline-flex items-center space-x-1 md:space-x-3">
+          {paths?.map((path, index) => (
+            <Fragment key={index}>
+              <li>
+                <div className="flex items-center">
+                  {index !== 0 && (
+                    <svg
+                      aria-hidden="true"
+                      className="w-6 h-6 text-gray-400"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                        clipRule="evenodd"
+                      ></path>
+                    </svg>
+                  )}
+                  <a href={path.url} className={activeClass(path.url)}>
+                    <p className="capitalize">{path.text}</p>
+                  </a>
+                </div>
+              </li>
+            </Fragment>
+          ))}
+        </ol>
+      </nav>
+    </div>
+  );
+};
+
+export default Breadcrumbs;


### PR DESCRIPTION
## Issue Link
- [LMS-312](https://framgiaph.backlog.com/view/LMS-312)

## Defintion of Done
- Able to show breadcrumbs depending on the url path

## Steps to reproduce
- create page/pages and import Breadcrumbs
- Example Links here
 -http://localhost:3000/demo/components#breadcrumbs

## Affected Components / Functionalities / Page
n/a

## Test Cases
_will update soon..._

## Notes
- I base the breadcrumbs in NextJS route structure, assuming that we use the proper routing, the breadcrumbs will be fine

## Screenshots
![image](https://user-images.githubusercontent.com/115448429/222325997-91790c5f-d804-42b2-92a2-0ff9b138b3bf.png)
![image](https://user-images.githubusercontent.com/115448429/222326058-8348db36-9a90-446c-ae64-c17e879d342c.png)
![image](https://user-images.githubusercontent.com/115448429/222616713-086d8e88-fafb-4e57-ad0f-c130e88dbc67.png)
![image](https://user-images.githubusercontent.com/115448429/223024331-30df7571-79b6-446b-82a2-7b4ee3bf1d91.png)



