### PR TITLE
[LMS-331][Bug Fix] Fixed Dropdown Issue

### DIFF
--- a/client/src/shared/components/Dropdown/index.tsx
+++ b/client/src/shared/components/Dropdown/index.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import ChevronDownIcon from '@/src/shared/icons/ChevronDownIcon';
+import { useOutsideClick } from '@/src/shared/hooks/useOutsideClick';
 
 export interface Option {
   text: string;
@@ -23,22 +24,7 @@ const Dropdown: React.FC<DropdownProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const handleDocumentClick = (event: MouseEvent): void => {
-      if (
-        dropdownRef.current != null &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener('click', handleDocumentClick);
-
-    return () => {
-      document.removeEventListener('click', handleDocumentClick);
-    };
-  }, []);
+  useOutsideClick(dropdownRef, () => { setIsOpen(false); });
 
   const handleOptionSelectEvent = (option: string): void => {
     setSelectedOption(option);

--- a/client/src/shared/hooks/useOutsideClick.tsx
+++ b/client/src/shared/hooks/useOutsideClick.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+export const useOutsideClick = (
+  ref: React.MutableRefObject<HTMLDivElement | null>,
+  callback: () => void
+): void => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (ref.current != null && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [callback, ref]);
+};


### PR DESCRIPTION
## Issue Link
[LMS-331](https://framgiaph.backlog.com/view/LMS-331)

## Defintion of Done
- useOutsideClick.tsx should be stored under src/shared/hooks
- Dropdown should implement the useEffect hook so that whenever users click outside the component it will trigger the component's state to close

## Steps to reproduce

1. cd client
2. npm run dev

- http://localhost:3000/demo/components#dropdown

## Affected Components / Functionalities / Page
n/a

## Test Cases
_will update soon..._

## Notes
Problem:
- There is no className prop in the component so when applied to the navbar, the border is still visible and there is no option to update it
- No useEffect in the dropdown component, the user still needs to click the component again to set the state to close

Solution:

- I added className as an optional prop so that when the dropdown component is implemented, the dev will have an option to add tailwindcss classes
- Applied useEffect and useRef in the component so that users of the component will no longer need to click the component to close it. Instead they can click anywhere in the page to set the state of the component to close

## Screenshots
![image](https://user-images.githubusercontent.com/122772532/224484144-35c91fda-9f65-46a7-a54c-d4938eed8f96.png)
![image](https://user-images.githubusercontent.com/122772532/224484117-f8a8e02a-dfad-431a-be10-4cd9bcc2bcc9.png)