### PR TITLE
[LMS-347][Integration] Sign In page

### DIFF
--- a/api/app/settings.py
+++ b/api/app/settings.py
@@ -38,6 +38,7 @@ DEBUG = env('DEBUG')
 # Application definition
 
 INSTALLED_APPS = [
+    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -46,12 +47,13 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'rest_framework.authtoken',
-    'corsheaders',
+    
     'app_sph_lms',
     'django_filters'
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -59,7 +61,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
+    
 ]
 
 ROOT_URLCONF = 'app.urls'
@@ -145,6 +147,9 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 ALLOWED_HOSTS = ['*']
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:3000',
+]
 CORS_ORIGIN_ALLOW_ALL = True
 
 REST_FRAMEWORK = {

--- a/api/app_sph_lms/api/serializers.py
+++ b/api/app_sph_lms/api/serializers.py
@@ -1,5 +1,15 @@
-from app_sph_lms.models import Course, CourseCategory
+from app_sph_lms.models import Course, CourseCategory, User
 from rest_framework import serializers
+
+class UserSerializer(serializers.ModelSerializer):
+    full_name = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = User
+        fields = "__all__"
+        
+    def get_full_name(self, obj):
+        return f'{obj.first_name} {obj.last_name}'
 
 class CourseCategorySerializer(serializers.ModelSerializer):
     class Meta:

--- a/api/app_sph_lms/api/views.py
+++ b/api/app_sph_lms/api/views.py
@@ -1,6 +1,8 @@
 from app_sph_lms.api.serializers import (CourseCategorySerializer,
-                                         CourseSerializer)
-from app_sph_lms.models import Course, CourseCategory
+                                         CourseSerializer,
+                                         UserSerializer
+                                         )
+from app_sph_lms.models import Course, CourseCategory, User
 from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import generics
@@ -10,6 +12,7 @@ from rest_framework.decorators import api_view
 from rest_framework.authtoken.models import Token
 from django.contrib.auth.backends import BaseBackend
 from django.contrib.auth.backends import get_user_model
+
 
 # Create your views here.
 
@@ -30,13 +33,17 @@ class AuthViaEmail(BaseBackend):
             return None
 
 @api_view()
-def get_auth_user(request):
+def get_auth_user( request):
     if request.method == 'GET':
         user = request.user
         token = Token.objects.get(user=user)
+        user = User.objects.get(id=user.id)
+        serializer =  UserSerializer(user)
+        
         return Response({
-            'username': user.username,
-            'email': user.email,
+            'full_name': serializer.data["full_name"],
+            'username': serializer.data["username"],
+            'email': serializer.data["email"],
             'auth_token': token.key,
         })   
 

--- a/client/src/apis/index.ts
+++ b/client/src/apis/index.ts
@@ -1,7 +1,13 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import axios from 'axios';
+import { getUserToken } from '@/src/shared/utils';
 
-const axiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL
+const API = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  headers: {
+    Accept: 'application/json',
+    Authorization: `Token ${getUserToken() ?? ''}`
+  }
 });
 
-export default axiosInstance;
+export default API;

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -3,11 +3,14 @@ import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
 import 'react-toastify/dist/ReactToastify.css';
 import { ToastContainer } from 'react-toastify';
+import { useAuthMiddleware } from '@/src/shared/hooks/useAuthMiddleware';
 
 const App: React.FunctionComponent<AppProps> = ({
   Component,
   pageProps
 }: AppProps) => {
+  useAuthMiddleware();
+
   return (
     <Fragment>
       <Component {...pageProps} />

--- a/client/src/pages/auth/sign-in/index.tsx
+++ b/client/src/pages/auth/sign-in/index.tsx
@@ -1,43 +1,20 @@
-/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import React, { Fragment, useState } from 'react';
-
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
+import React, { Fragment } from 'react';
 import Container from '@/src/shared/layouts/Container';
 import Navbar from '@/src/shared/components/Navbar';
 import { dropdownItems, navItems } from '../../demo/layouts/navbar';
-
+import { useAuthSignIn } from '@/src/shared/hooks/useAuthSignIn';
 const SignIn: React.FC = () => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [emailError, setEmailError] = useState<string | undefined>('');
-  const [passwordError, setPasswordError] = useState<string | undefined>('');
-
-  const handleSubmitEvent = (e: React.FormEvent<HTMLFormElement>): void => {
-    e.preventDefault();
-    if (!email) {
-      setEmailError('Email cannot be empty.');
-    }
-    if (!password) {
-      setPasswordError('Password cannot be empty.');
-    }
-    if (email && password) {
-      console.log('Frontend validations successful');
-    }
-  };
-
-  const handleEmailChangeEvent = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ): void => {
-    setEmail(e.target.value);
-    setEmailError('');
-  };
-
-  const handlePasswordChangeEvent = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ): void => {
-    setPassword(e.target.value);
-    setPasswordError('');
-  };
+  const {
+    email,
+    password,
+    emailError,
+    passwordError,
+    handleSubmitEvent,
+    handleEmailChangeEvent,
+    handlePasswordChangeEvent
+  } = useAuthSignIn();
 
   return (
     <Fragment>

--- a/client/src/pages/home/index.tsx
+++ b/client/src/pages/home/index.tsx
@@ -1,5 +1,4 @@
 import { Fragment, type ReactNode } from 'react';
-
 import Navbar from '@/src/shared/components/Navbar';
 import { dropdownItems, navItems } from '@/src/shared/utils/navBarList';
 

--- a/client/src/pages/trainer/courses/list/index.tsx
+++ b/client/src/pages/trainer/courses/list/index.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react';
 import GridIcon from '@/src/shared/icons/GridIcon';
 import ListIcon from '@/src/shared/icons/ListIcon';
 import ViewAs from '@/src/sections/courses/list/view-as';
-import axiosInstance from '@/src/apis';
+import API from '@/src/apis';
 import SearchBar from '@/src/shared/components/SearchBar/SearchBar';
 import { type Course } from '@/src/shared/utils';
 import useSortByCourse from '@/src/shared/hooks/useSortByCourse';
@@ -25,13 +25,8 @@ export interface CourseProps {
 }
 
 const View = (): ReactNode => {
-  const {
-    setData,
-    data,
-    handleSortDirectionChange,
-    options,
-    sortDirection
-  } = useSortByCourse();
+  const { setData, data, handleSortDirectionChange, options, sortDirection } =
+    useSortByCourse();
 
   const [selectedView, setSelectedView] = useState('grid');
 
@@ -53,7 +48,7 @@ const View = (): ReactNode => {
   useEffect(() => {
     let ignore = false;
     async function fetchData (): Promise<void> {
-      const response = await axiosInstance.get('/course');
+      const response = await API.get('/course');
       if (!ignore) {
         setData(response.data);
       }
@@ -76,7 +71,7 @@ const View = (): ReactNode => {
         <div className="bg-white top-0 bottom-0 w-3/5 left-20 ml-28 pr-10">
           <div className="text-xl pl-5 pt-20 text-blue-500">Courses</div>
           <div className="pl-5 pt-10">
-          <SearchBar onSearchEvent={handleOnSearchEvent} />
+            <SearchBar onSearchEvent={handleOnSearchEvent} />
             <div className="pt-5 flex flex-row justify-between">
               <div className="">
                 <Select

--- a/client/src/shared/components/Avatar/index.tsx
+++ b/client/src/shared/components/Avatar/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export interface AvatarProps {
-  name: string;
+  name: string | null;
 }
 
 const Avatar: React.FC<AvatarProps> = ({ name }) => {
@@ -16,9 +16,11 @@ const Avatar: React.FC<AvatarProps> = ({ name }) => {
     return initials.join('').toUpperCase();
   };
   return (
-      <div className="rounded-full bg-gray-300 w-8 h-8 flex items-center justify-center relative">
-        <span className="text-center text-white text-sm font-medium">{getInitials(name)}</span>
-      </div>
+    <div className="rounded-full bg-gray-300 w-8 h-8 flex items-center justify-center relative">
+      <span className="text-center text-white text-sm font-medium">
+        {getInitials(name)}
+      </span>
+    </div>
   );
 };
 

--- a/client/src/shared/components/Dropdown/index.tsx
+++ b/client/src/shared/components/Dropdown/index.tsx
@@ -8,7 +8,7 @@ export interface Option {
 }
 
 export interface DropdownProps {
-  label: string;
+  label: string | null;
   options: Option[];
   classNames?: string;
 }
@@ -24,7 +24,9 @@ const Dropdown: React.FC<DropdownProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  useOutsideClick(dropdownRef, () => { setIsOpen(false); });
+  useOutsideClick(dropdownRef, () => {
+    setIsOpen(false);
+  });
 
   const handleOptionSelectEvent = (option: string): void => {
     setSelectedOption(option);

--- a/client/src/shared/components/Navbar/index.tsx
+++ b/client/src/shared/components/Navbar/index.tsx
@@ -1,10 +1,11 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import React, { useEffect } from 'react';
 import Link from 'next/link';
 import Avatar from '@/src/shared/components/Avatar';
 import Dropdown, { type DropdownProps } from '@/src/shared/components/Dropdown';
 import NavLink from '@/src/shared/components/NavLink';
 import SettingsIcon from '@/src/shared/icons/SettingsIcon';
-import { isSignedIn } from '../../utils';
+import { getUserFullName, isSignedIn } from '../../utils';
 
 export interface NavItemProps {
   url: string;
@@ -62,8 +63,8 @@ const Navbar: React.FC<NavbarProps> = ({ navItems, dropdownItems }) => {
               <Link href={'/settings'} className="text-gray-600">
                 <SettingsIcon width={20} height={20} className="mr-2" />
               </Link>
-              <Avatar name="John Doe" />
-              <Dropdown options={dropdownItems} label="John Doe" />
+              <Avatar name={getUserFullName()} />
+              <Dropdown options={dropdownItems} label={getUserFullName()} />
             </div>
               )
             : (

--- a/client/src/shared/hooks/useAuthMiddleware.ts
+++ b/client/src/shared/hooks/useAuthMiddleware.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import API from '@/src/apis';
+import { useRouter } from 'next/router';
+import { getUserToken } from '../utils';
+
+export const useAuthMiddleware = (): any => {
+  const router = useRouter();
+
+  // we can modify this later for role specific routes
+  // we can also add middleware for logout functionality
+  if (getUserToken() !== null) {
+    const fetchData = async (): Promise<void> => {
+      try {
+        const user = await API.get('/auth/user');
+        localStorage.setItem('user_full_name', user.data.full_name);
+        localStorage.setItem('user_username', user.data.username);
+        localStorage.setItem('user_email', user.data.email);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    fetchData();
+
+    if (router.asPath === '/' || router.asPath === '/auth/sign-in') {
+      router.push('/home');
+    }
+  }
+};

--- a/client/src/shared/hooks/useAuthSignIn.ts
+++ b/client/src/shared/hooks/useAuthSignIn.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+/* eslint-disable object-shorthand */
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
+import { alertError, alertSuccess } from '@/src/shared/utils';
+import axios from 'axios';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+export const useAuthSignIn = (): any => {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [emailError, setEmailError] = useState<string | undefined>('');
+  const [passwordError, setPasswordError] = useState<string | undefined>('');
+
+  const handleSubmitEvent = async (
+    e: React.FormEvent<HTMLFormElement>
+  ): Promise<void> => {
+    e.preventDefault();
+    if (!email) {
+      setEmailError('Email cannot be empty.');
+    }
+    if (!password) {
+      setPasswordError('Password cannot be empty.');
+    }
+    if (email && password) {
+      const postData = {
+        username: email,
+        password: password
+      };
+
+      try {
+        const result = await axios.post(
+          `${process.env.NEXT_PUBLIC_API_BASE_URL}auth/sign-in`,
+          postData
+        );
+        localStorage.setItem('user_token', result.data.token);
+        localStorage.setItem('signedIn', 'true');
+        router.reload();
+        alertSuccess('Login Successful');
+      } catch (error) {
+        console.log(error);
+
+        alertError('Wrong Credentials');
+      }
+    }
+  };
+
+  const handleEmailChangeEvent = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    setEmail(e.target.value);
+    setEmailError('');
+  };
+
+  const handlePasswordChangeEvent = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    setPassword(e.target.value);
+    setPasswordError('');
+  };
+
+  return {
+    email,
+    password,
+    emailError,
+    passwordError,
+    handleSubmitEvent,
+    handleEmailChangeEvent,
+    handlePasswordChangeEvent
+  };
+};

--- a/client/src/shared/hooks/useCreateCourse.ts
+++ b/client/src/shared/hooks/useCreateCourse.ts
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import type { SelectOptionData } from '@/src/shared/components/Select';
 import { useRouter } from 'next/router';
-import axiosInstance from '@/src/apis';
+import API from '@/src/apis';
 import { alertError, alertSuccess, isRequestOk } from '../utils';
 
 export const useCreateCourse = (): any => {
@@ -32,7 +32,7 @@ export const useCreateCourse = (): any => {
   ): Promise<void> => {
     e.preventDefault();
     try {
-      const result = await axiosInstance.post('/course/', postData);
+      const result = await API.post('/course/', postData);
       alertSuccess('Course Successfully Added');
       router.push(`/trainer/course/detail/${result.data.id}`);
     } catch (error) {
@@ -54,7 +54,7 @@ export const useCreateCourse = (): any => {
   useEffect(() => {
     const fetchData = async (): Promise<void> => {
       try {
-        const result = await axiosInstance.get('/course-category');
+        const result = await API.get('/course-category');
         if (isRequestOk(result)) {
           setCategory(result.data);
         }

--- a/client/src/shared/hooks/useFilterCourse.tsx
+++ b/client/src/shared/hooks/useFilterCourse.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import { useState, useEffect } from 'react';
-import axiosInstance from '@/src/apis';
+import API from '@/src/apis';
 import type { Course, CourseCategory } from '../utils/interface';
 
 export interface FilterCourseState {
@@ -36,7 +36,7 @@ const useFilterCourse = (): FilterCourseState => {
         params.title = searchTerm;
       }
       endpoint += `?${new URLSearchParams(params).toString()}`;
-      const result = await axiosInstance.get<Course[]>(endpoint);
+      const result = await API.get<Course[]>(endpoint);
       setCourses(result.data);
     };
     void fetchCourses();
@@ -44,7 +44,7 @@ const useFilterCourse = (): FilterCourseState => {
 
   useEffect(() => {
     const fetchCategories = async (): Promise<void> => {
-      const result = await axiosInstance.get<CourseCategory[]>('/course-category/');
+      const result = await API.get<CourseCategory[]>('/course-category/');
       setCategories(result.data);
     };
     void fetchCategories();
@@ -70,7 +70,7 @@ const useFilterCourse = (): FilterCourseState => {
       params.title = searchTerm;
     }
     const endpoint = `?${new URLSearchParams(params).toString()}`;
-    const result = await axiosInstance.get<Course[]>(endpoint);
+    const result = await API.get<Course[]>(endpoint);
     setCourses(result.data);
   };
 

--- a/client/src/shared/hooks/useSearchCourse.ts
+++ b/client/src/shared/hooks/useSearchCourse.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import axiosInstance from '@/src/apis';
+import API from '@/src/apis';
 import type { Course } from '../utils/interface';
 
 export const useSearchCourse = (): any => {
@@ -8,7 +8,7 @@ export const useSearchCourse = (): any => {
   useEffect(() => {
     let ignore = false;
     async function fetchData (): Promise<void> {
-      const result = await axiosInstance.get('/course/');
+      const result = await API.get('/course/');
       if (!ignore) {
         setCourses(result.data);
       }
@@ -23,7 +23,7 @@ export const useSearchCourse = (): any => {
 
   const handleOnSearchEvent = async (searchTerm: string): Promise<void> => {
     try {
-      const result = await axiosInstance.get(`/course/?title=${searchTerm}`);
+      const result = await API.get(`/course/?title=${searchTerm}`);
       setCourses(result.data);
     } catch (error) {
       console.error(error);

--- a/client/src/shared/hooks/useShowPerPage.ts
+++ b/client/src/shared/hooks/useShowPerPage.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import axiosInstance from '@/src/apis';
+import API from '@/src/apis';
 import axios from 'axios';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -42,7 +42,7 @@ export const useShowPerPage = (): any => {
     const fetchCourse = async (): Promise<void> => {
       if (params.id !== undefined) {
         try {
-          const result = await axiosInstance.get(`course/${params.id}`);
+          const result = await API.get(`course/${params.id}`);
           if (isRequestOk(result)) {
             setCourse(result.data);
           }
@@ -61,7 +61,6 @@ export const useShowPerPage = (): any => {
   const handleShowPerPage = (e: any): void => {
     const limiter = e.target.value;
     setShowPerPage(users.slice(0, limiter));
-    console.log(showPerPage);
   };
 
   const paths = [

--- a/client/src/shared/hooks/useSortByCourse.ts
+++ b/client/src/shared/hooks/useSortByCourse.ts
@@ -1,4 +1,4 @@
-import axiosInstance from '@/src/apis';
+import API from '@/src/apis';
 import { useEffect, useState } from 'react';
 import { type SelectOptionData } from '../components/Select';
 import { type Course } from '../utils';
@@ -22,7 +22,7 @@ const useSortByCourse = (): any => {
   useEffect(() => {
     async function fetchdata (): Promise<void> {
       try {
-        const response = await axiosInstance.get<Course[]>(
+        const response = await API.get<Course[]>(
           `course/?sort=${sortDirection === ASC ? 'title_asc' : 'title_desc'}`
         );
         setData(response.data);

--- a/client/src/shared/utils/auth.ts
+++ b/client/src/shared/utils/auth.ts
@@ -1,3 +1,25 @@
 export const isSignedIn = (): boolean =>
   typeof localStorage !== 'undefined' &&
-  localStorage.getItem('signedIn') === 'false';
+  localStorage.getItem('signedIn') === 'true';
+
+export const getUserToken = (): string | null => {
+  if (
+    typeof localStorage !== 'undefined' &&
+    localStorage.getItem('user_token') !== undefined
+  ) {
+    return localStorage.getItem('user_token');
+  } else {
+    return null;
+  }
+};
+
+export const getUserFullName = (): string | null => {
+  if (
+    typeof localStorage !== 'undefined' &&
+    localStorage.getItem('user_token') !== undefined
+  ) {
+    return localStorage.getItem('user_full_name');
+  } else {
+    return null;
+  }
+};


### PR DESCRIPTION
## Issue Link
[LMS-347 [Integration] Sign-in Page](https://framgiaph.backlog.com/view/LMS-347)

## Defintion of Done
* [x] it must be able to sign-in
* [x] it must redirect to home page after sign-in `/home`
* [x] when signed-in, it should not be able to access landing page `/`. When input manually, it should auto redirect to `/home`
* [x] when signed-in, it should not be able to access sign in page `/auth/sign-in`. When input manually, it should auto redirect to `/home`
* [x] It must display dynamic user or profile name
* [x] it must retrieve the `token` from backend and store it to cache or localstorage to keep the user signed-in when accessing to different page
* [x] also store necessary user details
* [x] create auth middleware

## Steps to reproduce
Follow the step to reproduce of the new migration file:
[Reference](https://github.com/framgia/sph-lms/pull/55)

Got to [Sign In Page](http://localhost:3000/auth/sign-in)
 - Creds
 -- admin@gmail.com
 -- password
 - access landing page manually (should return to /home)
 - access sign in page manually (should return to /home)
 
## Affected Components / Functionalities / Page
n/a

## Test Cases
_will update soon..._

## Notes
- /home page has hydration error which is not a part of my task, just close the error modal adn test features of my task only

## Screenshots
![image](https://user-images.githubusercontent.com/115448429/227887698-a356b3c6-b58f-4079-a6ad-acb866855883.png)
![image](https://user-images.githubusercontent.com/115448429/227887844-a769c7f5-8431-4a35-904c-0e1621839e46.png)
![image](https://user-images.githubusercontent.com/115448429/228176591-6c94a60e-6c01-436e-8af6-5425285e431d.png)
![image](https://user-images.githubusercontent.com/115448429/228172301-a65a7bcb-fbaa-4655-9e33-192e9499cd3d.png)

