### PR TITLE
[LMS-354][FE][Markup][Reusable] Add Modal & Edit Modal

### DIFF
--- a/client/src/pages/demo/components/index.tsx
+++ b/client/src/pages/demo/components/index.tsx
@@ -249,6 +249,7 @@ const DemoComponent: React.FunctionComponent = () => {
               <p> id: (string)[""] ex. label="Testing"</p>
               <p> width: "100%" | "50px",</p>
               <p>height: "100%" | "50px"</p>
+              <p>className:(string)[""] ex. 'bg-red-500 w-5 h-5'</p>
             </div>
           </div>
 
@@ -262,18 +263,18 @@ const DemoComponent: React.FunctionComponent = () => {
             <Button text="Plain" />
             <Button
               text="Submit"
-              color="blue"
-              width="200px"
+              color="bg-blue-700"
+              width="w-1/4"
               onClick={() => {
                 console.log('I clicked Submit button');
               }}
             />
-            <Button text="Okay" color="green" width="50%" />
-            <Button text="Delete" color="red" width="75%" />
+            <Button text="Okay" color="bg-green-500" width="w-82" />
+            <Button text="Delete" color="bg-red-500" width="w-full" />
             <Button
               text="Edit"
-              color="yellow"
-              width="100%"
+              color="bg-yellow-500"
+              width="w-3/4"
               onClick={() => {
                 alert('Clicked yellow button, this is a function');
               }}

--- a/client/src/pages/users/[company_id]/list/index.tsx
+++ b/client/src/pages/users/[company_id]/list/index.tsx
@@ -224,8 +224,9 @@ const UsersList: React.FC = () => {
             <XmarkIcon />
           </div>
         </div>
-        <div className='text-lg px-6 pb-6'>{confirmationMessage}</div>
-        <div className='flex justify-end mr-6'>
+        <div className='text-lg px-6 pb-10'>{confirmationMessage}</div>
+        <div className='flex justify-between mx-6'>
+          <Button text='Cancel' color='red' onClick={() => { setIsConfirmationModalOpen(false); }}/>
           <Button text='Confirm' color='blue' onClick={handleConfirm} />
         </div>
       </Modal>

--- a/client/src/pages/users/[company_id]/list/index.tsx
+++ b/client/src/pages/users/[company_id]/list/index.tsx
@@ -47,7 +47,7 @@ const UsersList: React.FC = () => {
         <Modal isOpen={isAddModalOpen}>
           <div className='flex justify-between relative mx-6' >
             <div>
-              <h1 className='text-3xl mt-6 mb-14'>Add a new User</h1>
+              <h1 className='text-3xl mt-6 mb-9'>Add a new User</h1>
             </div>
             <div className='mt-8 cursor-pointer' onClick={() => { setIsAddModalOpen(false); }}>
               <XmarkIcon />
@@ -91,7 +91,7 @@ const UsersList: React.FC = () => {
         <Modal isOpen={isEditModalOpen}>
           <div className='flex justify-between relative mx-6 sticky'>
             <div>
-              <h1 className='text-3xl mt-6 mb-14'>John Strong</h1>
+              <h1 className='text-3xl mt-6 mb-9'>John Strong</h1>
             </div>
             <div className='mt-8 cursor-pointer' onClick={() => { setIsEditModalOpen(false); }}>
               <XmarkIcon />

--- a/client/src/pages/users/[company_id]/list/index.tsx
+++ b/client/src/pages/users/[company_id]/list/index.tsx
@@ -1,259 +1,169 @@
-import { Fragment, useState } from 'react';
-
 import Button from '@/src/shared/components/Button';
 import InputField from '@/src/shared/components/InputField';
 import Modal from '@/src/shared/components/Modal/Modal';
-import Select, { type SelectOptionData } from '@/src/shared/components/Select';
 import EditIcon from '@/src/shared/icons/EditIcon';
 import XmarkIcon from '@/src/shared/icons/XmarkIcon';
+import useEditAddUser from '@/src/shared/hooks/useEditAddUser';
+import Select from '@/src/shared/components/Select';
 
 const UsersList: React.FC = () => {
-  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-
-  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-
-  const [validation, setValidation] = useState('');
-
-  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
-
-  const [confirmationMessage, setConfirmationMessage] = useState('');
-
-  const handleOpenAddModal = (): void => {
-    setIsAddModalOpen(true);
-  };
-
-  const handleOpenEditModal = (): void => {
-    setIsEditModalOpen(true);
-  };
-
-  const ONE = '1';
-
-  const TWO = '2';
-
-  const THREE = '3';
-
-  const options: SelectOptionData[] = [
-    { id: 1, text: 'Admin' },
-    { id: 2, text: 'Trainer' },
-    { id: 3, text: 'Trainee' }
-  ];
-
-  const [role, setRole] = useState<typeof ONE | typeof TWO | typeof THREE>(
-    ONE
-  );
-
-  const handleValueChange = (
-    event: React.ChangeEvent<HTMLSelectElement>
-  ): void => {
-    setRole(event.target.value as typeof ONE | typeof TWO | typeof THREE);
-  };
-
-  const [formData, setFormData] = useState({
-    firstName: '',
-    lastName: '',
-    email: '',
-    password: '',
-    confirmPassword: ''
-  });
-
-  const handleChange = (event: { target: { name: any; value: any; }; }): void => {
-    setFormData({
-      ...formData,
-      [event.target.name]: event.target.value
-    });
-  };
-
-  const handleSubmitUser = (event: React.FormEvent<HTMLFormElement>): void => {
-    event.preventDefault();
-    let errorMessages = '';
-    if (formData.firstName.length === 0 || formData.lastName.length === 0 || formData.email.length === 0) {
-      errorMessages = 'Please fill in all required fields.';
-    }
-    if (
-      formData.firstName.length < 3 ||
-      formData.lastName.length < 3) {
-      errorMessages = 'The First and Last name should be more than 2 characters';
-    }
-    const emailRegex = /^\S+@\S+\.\S+$/;
-    if (!emailRegex.test(formData.email)) {
-      errorMessages = 'Invalid Email Address';
-    }
-    if (errorMessages.length > 0) {
-      setValidation(errorMessages);
-    } else {
-      // TODO: Implement form submission logic here
-      setIsConfirmationModalOpen(true);
-      setConfirmationMessage('Are you sure you want to create user?'); // Open the confirmation modal
-      setValidation(''); // Clear validation error message
-    }
-  };
-
-  const handleSubmitEdit = (event: React.FormEvent<HTMLFormElement>): void => {
-    event.preventDefault();
-    let errorMessages = '';
-    if (formData.firstName.length === 0 || formData.lastName.length === 0 || formData.email.length === 0) {
-      errorMessages = 'Please fill in all required fields.';
-    }
-    const emailRegex = /^\S+@\S+\.\S+$/;
-    if (!emailRegex.test(formData.email)) {
-      errorMessages = 'Invalid email address';
-    }
-    if (
-      formData.firstName.length < 2 ||
-      formData.lastName.length < 2) {
-      errorMessages = 'The First and Last name should be more than 2 characters';
-    }
-    if (
-      formData.password.length < 5 ||
-      formData.confirmPassword.length < 5) {
-      errorMessages = 'Password should be more than 5 characters';
-    }
-    if (formData.password !== formData.confirmPassword) {
-      errorMessages = 'Passwords do not match.';
-    }
-    if (errorMessages.length > 0) {
-      setValidation(errorMessages);
-    } else {
-      // TODO: Implement form submission logic here
-      setIsConfirmationModalOpen(true);
-      setConfirmationMessage('Are you sure you want to edit user?');
-      setValidation(''); // Clear validation error message
-    }
-  };
-
-  const handleConfirm = (): void => {
-    setIsConfirmationModalOpen(false); // Close the confirmation modal
-    setIsEditModalOpen(false);
-    setIsAddModalOpen(false);
-  };
-
-  const handleDeleteUser = (): void => {
-    // TODO: Implement delete operation here
-    setIsConfirmationModalOpen(true); // Open the confirmation modal
-    setConfirmationMessage('Are you sure you want to delete user?'); // Set the confirmation message
-  };
+  const {
+    isAddModalOpen,
+    isEditModalOpen,
+    isConfirmationModalOpen,
+    confirmationMessage,
+    handleOpenAddModal,
+    handleOpenEditModal,
+    options,
+    role,
+    handleValueChange,
+    handleChange,
+    handleSubmitUser,
+    handleSubmitEdit,
+    handleConfirm,
+    handleDeleteUser,
+    formData,
+    setIsAddModalOpen,
+    setIsEditModalOpen,
+    setIsConfirmationModalOpen,
+    errorFistName,
+    errorLastName,
+    errorEmail,
+    errorPassword,
+    confirmPassword
+  } = useEditAddUser();
 
   return (
-    <Fragment>
-      <div className='ml-12 mb-12'>
-        <Button text='Add User' color='blue' width='20' onClick={handleOpenAddModal} />
-        <div onClick={handleOpenEditModal} className='cursor-pointer'>
-          <EditIcon />
-        </div>
-      </div>
-      <Modal isOpen={isAddModalOpen}>
-        <div className='flex justify-between relative mx-6'>
-          <div>
-            <h1 className='text-3xl mt-6 mb-14'>Add a new User</h1>
-          </div>
-          <div className='mt-8 cursor-pointer' onClick={() => { setIsAddModalOpen(false); }}>
-            <XmarkIcon />
+    <div>
+      <div>
+        <div className='ml-12 mb-12'>
+          <Button text='Add User' hover='hover:bg-blue-700' width='20' onClick={handleOpenAddModal} />
+          <div onClick={handleOpenEditModal} className='cursor-pointer'>
+            <EditIcon classname='text-blue-700 w-7 h-7 font-extrabold text-xl' />
           </div>
         </div>
-        <form onSubmit={handleSubmitUser}>
-          <div className='space-y-6 pb-5'>
-            <div>
-              <label className='ml-6 text-sm font-bold'>Role</label>
-              <div className='mx-6'>
-                <Select options={options} value={role} eventHandler={handleValueChange} />
-              </div>
-            </div>
-            <div>
-              <label className='ml-6 text-sm font-bold'>First Name</label>
-              <div className='mx-6'>
-                <InputField value={formData.firstName} eventHandler={handleChange} name="firstName" />
-              </div>
-            </div>
-            <div>
-              <label className='ml-6 text-sm font-bold'>Last Name</label>
-              <div className='mx-6'>
-                <InputField value={formData.lastName} eventHandler={handleChange} name="lastName" />
-              </div>
-            </div>
-            <div>
-              <label className='ml-6 text-sm font-bold'>Email</label>
-              <div className='mx-6'>
-                <InputField value={formData.email} eventHandler={handleChange} name="email" />
-              </div>
-            </div>
-            {(validation.length > 0) && <p className='text-red-500 ml-6 mb-6'>{validation}</p>}
-          </div>
-          <div className='flex justify-end mr-6'>
-            <Button text='Create New User' color='blue' type='submit' />
-          </div>
-        </form>
-      </Modal>
-      <Modal isOpen={isEditModalOpen}>
-        <div className='flex justify-between relative mx-6'>
-          <div>
-            <h1 className='text-3xl mt-6 mb-14'>John Strong</h1>
-          </div>
-          <div className='mt-8 cursor-pointer' onClick={() => { setIsEditModalOpen(false); }}>
-            <XmarkIcon />
-          </div>
+        <div>
         </div>
-        <form onSubmit={handleSubmitEdit}>
-          <div className='space-y-6 pb-5'>
+        <Modal isOpen={isAddModalOpen}>
+          <div className='flex justify-between relative mx-6' >
             <div>
-              <label className='ml-6 text-sm font-bold'>Role</label>
-              <div className='mx-6'>
-                <Select options={options} value={role} eventHandler={handleValueChange} />
-              </div>
+              <h1 className='text-3xl mt-6 mb-14'>Add a new User</h1>
             </div>
-            <div>
-              <label className='ml-6 text-sm font-bold'>Email</label>
-              <div className='mx-6'>
-                <InputField value={formData.email} eventHandler={handleChange} name="email" />
-              </div>
+            <div className='mt-8 cursor-pointer' onClick={() => { setIsAddModalOpen(false); }}>
+              <XmarkIcon />
             </div>
-            <div>
-              <label className='ml-6 text-sm font-bold'>First Name</label>
-              <div className='mx-6'>
-                <InputField value={formData.firstName} eventHandler={handleChange} name="firstName" />
-              </div>
-            </div>
-            <div>
-              <label className='ml-6 text-sm font-bold'>Last Name</label>
-              <div className='mx-6'>
-                <InputField value={formData.lastName} eventHandler={handleChange} name="lastName" />
-              </div>
-            </div>
-            <div>
-              <label className='ml-6 text-sm font-bold'>Password</label>
-              <div className='mx-6'>
-                <InputField value={formData.password} eventHandler={handleChange} name="password" type='password' />
-              </div>
-            </div>
-            <div>
-              <label className='ml-6 text-sm font-bold'>Confirm Password</label>
-              <div className='mx-6'>
-                <InputField value={formData.confirmPassword} eventHandler={handleChange} name="confirmPassword" type='password' />
-              </div>
-            </div>
-            {(validation.length > 0) && <p className='text-red-500 ml-6 mb-6'>{validation}</p>}
           </div>
+          <form onSubmit={handleSubmitUser}>
+            <div className='space-y-6 pb-5'>
+              <div>
+                <label className='ml-6 text-sm font-bold'>Role</label>
+                <div className='mx-6'>
+                  <Select options={options} value={role} eventHandler={handleValueChange} />
+                </div>
+              </div>
+              <div>
+                <label className='ml-6 text-sm font-bold'>First Name</label>
+                <div className='mx-6'>
+                  <InputField value={formData.firstName} eventHandler={handleChange} name="firstName" />
+                  {(errorFistName.length > 0) && <span className='text-red-500'>{errorFistName}</span>}
+                </div>
+              </div>
+              <div>
+                <label className='ml-6 text-sm font-bold'>Last Name</label>
+                <div className='mx-6'>
+                  <InputField value={formData.lastName} eventHandler={handleChange} name="lastName" />
+                  {(errorLastName.length > 0) && <span className='text-red-500'>{errorLastName}</span>}
+                </div>
+              </div>
+              <div>
+                <label className='ml-6 text-sm font-bold'>Email</label>
+                <div className='mx-6'>
+                  <InputField value={formData.email} eventHandler={handleChange} name="email" />
+                  {(errorEmail.length > 0) && <span className='text-red-500'>{errorEmail}</span>}
+                </div>
+              </div>
+            </div>
+            <div className='flex justify-end mr-6'>
+              <Button text='Create New User' type='submit' />
+            </div>
+          </form>
+        </Modal>
+        <Modal isOpen={isEditModalOpen}>
+          <div className='flex justify-between relative mx-6 sticky'>
+            <div>
+              <h1 className='text-3xl mt-6 mb-14'>John Strong</h1>
+            </div>
+            <div className='mt-8 cursor-pointer' onClick={() => { setIsEditModalOpen(false); }}>
+              <XmarkIcon />
+            </div>
+          </div>
+          <form onSubmit={handleSubmitEdit}>
+            <div className='space-y-6 pb-5'>
+              <div>
+                <label className='ml-6 text-sm font-bold'>Role</label>
+                <div className='mx-6'>
+                  <Select options={options} value={role} eventHandler={handleValueChange} />
+                </div>
+              </div>
+              <div>
+                <label className='ml-6 text-sm font-bold'>Email</label>
+                <div className='mx-6'>
+                  <InputField value={formData.email} eventHandler={handleChange} name="email" />
+                  {(errorEmail.length > 0) && <span className='text-red-500'>{errorEmail}</span>}
+                </div>
+              </div>
+              <div>
+                <label className='ml-6 text-sm font-bold'>First Name</label>
+                <div className='mx-6'>
+                  <InputField value={formData.firstName} eventHandler={handleChange} name="firstName" />
+                  {(errorFistName.length > 0) && <span className='text-red-500'>{errorFistName}</span>}
+                </div>
+              </div>
+              <div>
+                <label className='ml-6 text-sm font-bold'>Last Name</label>
+                <div className='mx-6'>
+                  <InputField value={formData.lastName} eventHandler={handleChange} name="lastName" />
+                  {(errorLastName.length > 0) && <span className='text-red-500'>{errorLastName}</span>}
+                </div>
+              </div>
+              <div>
+                <label className='ml-6 text-sm font-bold'>Password</label>
+                <div className='mx-6'>
+                  <InputField value={formData.password} eventHandler={handleChange} name="password" type='password' />
+                  {(errorPassword.length > 0) && <span className='text-red-500'>{errorPassword}</span>}
+                </div>
+              </div>
+              <div>
+                <label className='ml-6 text-sm font-bold'>Confirm Password</label>
+                <div className='mx-6'>
+                  <InputField value={formData.confirmPassword} eventHandler={handleChange} name="confirmPassword" type='password' />
+                  {(confirmPassword.length > 0) && <span className='text-red-500'>{confirmPassword}</span>}
+                </div>
+              </div>
+            </div>
+            <div className='flex justify-between mx-6'>
+              <Button text='Delete User' color='red' hover='hover:bg-red-600' onClick={handleDeleteUser} />
+              <Button text='Update User' hover='hover:bg-blue-700' type='submit' />
+            </div>
+          </form>
+        </Modal>
+        <Modal isOpen={isConfirmationModalOpen}>
+          <div className='flex justify-between relative mr-6'>
+            <div>
+              <h1 className='text-3xl mt-6 ml-6 mb-14'>Confirmation</h1>
+            </div>
+            <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsConfirmationModalOpen(false); }}>
+              <XmarkIcon />
+            </div>
+          </div>
+          <div className='text-lg px-6 pb-10'>{confirmationMessage}</div>
           <div className='flex justify-between mx-6'>
-            <Button text='Delete User' color='red' onClick={handleDeleteUser} />
-            <Button text='Update User' color='blue' type='submit' />
+            <Button text='Cancel' color='red' hover='hover:bg-red-600' onClick={() => { setIsConfirmationModalOpen(false); }} />
+            <Button text='Confirm' hover='hover:bg-blue-700' onClick={handleConfirm} />
           </div>
-        </form>
-      </Modal>
-      <Modal isOpen={isConfirmationModalOpen}>
-        <div className='flex justify-between relative mr-6'>
-          <div>
-            <h1 className='text-3xl mt-6 ml-6 mb-14'>Confirmation</h1>
-          </div>
-          <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsConfirmationModalOpen(false); }}>
-            <XmarkIcon />
-          </div>
-        </div>
-        <div className='text-lg px-6 pb-10'>{confirmationMessage}</div>
-        <div className='flex justify-between mx-6'>
-          <Button text='Cancel' color='red' onClick={() => { setIsConfirmationModalOpen(false); }}/>
-          <Button text='Confirm' color='blue' onClick={handleConfirm} />
-        </div>
-      </Modal>
-    </Fragment>
+        </Modal>
+      </div>
+    </div>
   );
 };
 

--- a/client/src/pages/users/[company_id]/list/index.tsx
+++ b/client/src/pages/users/[company_id]/list/index.tsx
@@ -1,0 +1,167 @@
+import Button from '@/src/shared/components/Button';
+import InputField from '@/src/shared/components/InputField';
+import Modal from '@/src/shared/components/Modal/Modal';
+import Select, { type SelectOptionData } from '@/src/shared/components/Select';
+import EditIcon from '@/src/shared/icons/EditIcon';
+import XmarkIcon from '@/src/shared/icons/XmarkIcon';
+import { Fragment, useState } from 'react';
+
+const UsersList: React.FC = () => {
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+
+  const [validation, setValidation] = useState('');
+
+  const handleOpenAddModal = (): void => {
+    setIsAddModalOpen(true);
+  };
+
+  const handleOpenEditModal = (): void => {
+    setIsEditModalOpen(true);
+  };
+
+  const ONE = '1';
+
+  const TWO = '2';
+
+  const THREE = '3';
+
+  const options: SelectOptionData[] = [
+    { id: 1, text: 'Admin' },
+    { id: 2, text: 'Trainer' },
+    { id: 3, text: 'Trainee' }
+  ];
+
+  const [role, setRole] = useState<typeof ONE | typeof TWO | typeof THREE>(
+    ONE
+  );
+
+  const handleValueChange = (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ): void => {
+    setRole(event.target.value as typeof ONE | typeof TWO | typeof THREE);
+  };
+
+  const [formData, setFormData] = useState({
+    firstName: '',
+    lastName: '',
+    email: ''
+  });
+
+  const handleChange = (event: { target: { name: any; value: any; }; }): void => {
+    setFormData({
+      ...formData,
+      [event.target.name]: event.target.value
+    });
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    if (formData.firstName.length === 0 || formData.lastName.length === 0 || formData.email.length === 0) {
+      setValidation('Please fill in all required fields.');
+    } else {
+      // TODO: Implement form submission logic here
+      setIsAddModalOpen(false); // Close modal after form submission
+      setValidation(''); // Clear validation error message
+    }
+  };
+
+  return (
+    <Fragment>
+        <div>
+            <Button text='Add User' color='blue' width='20' onClick={handleOpenAddModal}/>
+            <div onClick={handleOpenEditModal}>
+            <EditIcon/>
+            </div>
+        </div>
+        <Modal isOpen={isAddModalOpen}>
+        <div className='flex justify-between relative mr-6'>
+    <div>
+      <h1 className='text-3xl mt-6 ml-6 mb-14'>Add a new User</h1>
+      </div>
+      <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsAddModalOpen(false); }}>
+      <XmarkIcon />
+      </div>
+    </div>
+          <form onSubmit={handleSubmit}>
+          <div className='space-y-6 pb-5'>
+          <div>
+            <label className='ml-6 text-sm font-bold'>Role</label>
+            <div className='mx-6'>
+            <Select options={options} value={role} eventHandler={handleValueChange}/>
+            </div>
+          </div>
+          <div>
+            <label className='ml-6 text-sm font-bold'>First Name</label>
+            <div className='mx-6'>
+            <InputField value= {formData.firstName} eventHandler={handleChange} name="firstName"/>
+            </div>
+          </div>
+          <div>
+            <label className='ml-6 text-sm font-bold'>Last Name</label>
+            <div className='mx-6'>
+            <InputField value={formData.lastName} eventHandler={handleChange} name="lastName"/>
+            </div>
+          </div>
+          <div>
+            <label className='ml-6 text-sm font-bold'>Email</label>
+            <div className='mx-6'>
+            <InputField value={formData.email} eventHandler={handleChange} name="email"/>
+            </div>
+          </div>
+          {(validation.length > 0) && <p className='text-red-500 ml-6 mb-6'>{validation}</p>}
+          </div>
+          <div className='flex justify-end mr-6'>
+      <Button text='Create New User' color='blue' type='submit'/>
+    </div>
+    </form>
+        </Modal>
+        <Modal isOpen={isEditModalOpen}>
+        <div className='flex justify-between relative mr-6'>
+    <div>
+      <h1 className='text-3xl mt-6 ml-6 mb-14'>John Strong</h1>
+      </div>
+      <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsEditModalOpen(false); }}>
+      <XmarkIcon />
+      </div>
+    </div>
+          <form onSubmit={handleSubmit}>
+          <div className='space-y-6 pb-5'>
+          <div>
+            <label className='ml-6 text-sm font-bold'>Role</label>
+            <div className='mx-6'>
+            <Select options={options} value={role} eventHandler={handleValueChange}/>
+            </div>
+          </div>
+          <div>
+            <label className='ml-6 text-sm font-bold'>First Name</label>
+            <div className='mx-6'>
+            <InputField value= {formData.firstName} eventHandler={handleChange} name="firstName"/>
+            </div>
+          </div>
+          <div>
+            <label className='ml-6 text-sm font-bold'>Last Name</label>
+            <div className='mx-6'>
+            <InputField value={formData.lastName} eventHandler={handleChange} name="lastName"/>
+            </div>
+          </div>
+          <div>
+            <label className='ml-6 text-sm font-bold'>Email</label>
+            <div className='mx-6'>
+            <InputField value={formData.email} eventHandler={handleChange} name="email"/>
+            </div>
+          </div>
+          {(validation.length > 0) && <p className='text-red-500 ml-6 mb-6'>{validation}</p>}
+          </div>
+          <div className='flex justify-end mr-6'>
+      <Button text='Create New User' color='blue' type='submit'/>
+    </div>
+    </form>
+        </Modal>
+
+        </Fragment>
+  );
+};
+
+export default UsersList;

--- a/client/src/pages/users/[company_id]/list/index.tsx
+++ b/client/src/pages/users/[company_id]/list/index.tsx
@@ -92,7 +92,6 @@ const UsersList: React.FC = () => {
       setValidation(errorMessages);
     } else {
       // TODO: Implement form submission logic here
-      setIsEditModalOpen(false); // Close modal after form submission
       setIsConfirmationModalOpen(true);
       setConfirmationMessage('Are you sure you want to edit user?');
       setValidation(''); // Clear validation error message

--- a/client/src/pages/users/[company_id]/list/index.tsx
+++ b/client/src/pages/users/[company_id]/list/index.tsx
@@ -13,6 +13,10 @@ const UsersList: React.FC = () => {
 
   const [validation, setValidation] = useState('');
 
+  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
+
+  const [confirmationMessage, setConfirmationMessage] = useState('');
+
   const handleOpenAddModal = (): void => {
     setIsAddModalOpen(true);
   };
@@ -46,7 +50,9 @@ const UsersList: React.FC = () => {
   const [formData, setFormData] = useState({
     firstName: '',
     lastName: '',
-    email: ''
+    email: '',
+    password: '',
+    confirmPassword: ''
   });
 
   const handleChange = (event: { target: { name: any; value: any; }; }): void => {
@@ -56,22 +62,62 @@ const UsersList: React.FC = () => {
     });
   };
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+  const handleSubmitUser = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
+    let errorMessages = '';
     if (formData.firstName.length === 0 || formData.lastName.length === 0 || formData.email.length === 0) {
-      setValidation('Please fill in all required fields.');
+      errorMessages = 'Please fill in all required fields.';
+    }
+    if (formData.password !== formData.confirmPassword) {
+      errorMessages = 'Passwords do not match.';
+    }
+    if (errorMessages.length > 0) {
+      setValidation(errorMessages);
     } else {
-      // TODO: Implement form submission logic here
-      setIsAddModalOpen(false); // Close modal after form submission
+    // TODO: Implement form submission logic here
+      setIsConfirmationModalOpen(true);
+      setConfirmationMessage('Are you sure you want to create user?'); // Open the confirmation modal
       setValidation(''); // Clear validation error message
     }
   };
 
+  const handleSubmitEdit = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    let errorMessages = '';
+    if (formData.firstName.length === 0 || formData.lastName.length === 0 || formData.email.length === 0) {
+      errorMessages = 'Please fill in all required fields.';
+    }
+    if (formData.password !== formData.confirmPassword) {
+      errorMessages = 'Passwords do not match.';
+    }
+    if (errorMessages.length > 0) {
+      setValidation(errorMessages);
+    } else {
+      // TODO: Implement form submission logic here
+      setIsEditModalOpen(false); // Close modal after form submission
+      setIsConfirmationModalOpen(true);
+      setConfirmationMessage('Are you sure you want to edit user?');
+      setValidation(''); // Clear validation error message
+    }
+  };
+
+  const handleConfirm = (): void => {
+    setIsConfirmationModalOpen(false); // Close the confirmation modal
+    setIsEditModalOpen(false);
+    setIsAddModalOpen(false);
+  };
+
+  const handleDeleteUser = (): void => {
+  // TODO: Implement delete operation here
+    setIsConfirmationModalOpen(true); // Open the confirmation modal
+    setConfirmationMessage('Are you sure you want to delete user?'); // Set the confirmation message
+  };
+
   return (
     <Fragment>
-        <div>
+        <div className='ml-12 mb-12'>
             <Button text='Add User' color='blue' width='20' onClick={handleOpenAddModal}/>
-            <div onClick={handleOpenEditModal}>
+            <div onClick={handleOpenEditModal} className='cursor-pointer'>
             <EditIcon/>
             </div>
         </div>
@@ -84,7 +130,7 @@ const UsersList: React.FC = () => {
       <XmarkIcon />
       </div>
     </div>
-          <form onSubmit={handleSubmit}>
+          <form onSubmit={handleSubmitUser}>
           <div className='space-y-6 pb-5'>
           <div>
             <label className='ml-6 text-sm font-bold'>Role</label>
@@ -126,12 +172,18 @@ const UsersList: React.FC = () => {
       <XmarkIcon />
       </div>
     </div>
-          <form onSubmit={handleSubmit}>
+          <form onSubmit={handleSubmitEdit}>
           <div className='space-y-6 pb-5'>
           <div>
             <label className='ml-6 text-sm font-bold'>Role</label>
             <div className='mx-6'>
             <Select options={options} value={role} eventHandler={handleValueChange}/>
+            </div>
+          </div>
+          <div>
+            <label className='ml-6 text-sm font-bold'>Email</label>
+            <div className='mx-6'>
+            <InputField value={formData.email} eventHandler={handleChange} name="email"/>
             </div>
           </div>
           <div>
@@ -147,19 +199,39 @@ const UsersList: React.FC = () => {
             </div>
           </div>
           <div>
-            <label className='ml-6 text-sm font-bold'>Email</label>
+            <label className='ml-6 text-sm font-bold'>Password</label>
             <div className='mx-6'>
-            <InputField value={formData.email} eventHandler={handleChange} name="email"/>
+            <InputField value={formData.password} eventHandler={handleChange} name="password" type='password'/>
+            </div>
+          </div>
+          <div>
+            <label className='ml-6 text-sm font-bold'>Confirm Password</label>
+            <div className='mx-6'>
+            <InputField value={formData.confirmPassword} eventHandler={handleChange} name="confirmPassword" type='password'/>
             </div>
           </div>
           {(validation.length > 0) && <p className='text-red-500 ml-6 mb-6'>{validation}</p>}
           </div>
-          <div className='flex justify-end mr-6'>
-      <Button text='Create New User' color='blue' type='submit'/>
+          <div className='flex justify-between mx-6'>
+            <Button text='Delete User' color='red' onClick={handleDeleteUser}/>
+      <Button text='Update User' color='blue' type='submit'/>
     </div>
     </form>
         </Modal>
-
+        <Modal isOpen={isConfirmationModalOpen}>
+  <div className='flex justify-between relative mr-6'>
+    <div>
+      <h1 className='text-3xl mt-6 ml-6 mb-14'>Confirmation</h1>
+    </div>
+    <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsConfirmationModalOpen(false); }}>
+      <XmarkIcon />
+    </div>
+  </div>
+  <div className='text-lg px-6 pb-6'>{confirmationMessage}</div>
+  <div className='flex justify-end mr-6'>
+    <Button text='Confirm' color='blue' onClick={handleConfirm}/>
+  </div>
+</Modal>
         </Fragment>
   );
 };

--- a/client/src/pages/users/[company_id]/list/index.tsx
+++ b/client/src/pages/users/[company_id]/list/index.tsx
@@ -36,130 +36,237 @@ const UsersList: React.FC = () => {
   return (
     <div>
       <div>
-        <div className='ml-12 mb-12'>
-          <Button text='Add User' hover='hover:bg-blue-700' width='20' onClick={handleOpenAddModal} />
-          <div onClick={handleOpenEditModal} className='cursor-pointer'>
-            <EditIcon classname='text-blue-700 w-7 h-7 font-extrabold text-xl' />
+        <div className="ml-12 mb-12">
+          <Button
+            text="Add User"
+            hover="hover:bg-blue-700"
+            width="20"
+            onClick={handleOpenAddModal}
+          />
+          <div onClick={handleOpenEditModal} className="cursor-pointer">
+            <EditIcon classname="text-blue-700 w-7 h-7 font-extrabold text-xl" />
           </div>
         </div>
-        <div>
-        </div>
+        <div></div>
         <Modal isOpen={isAddModalOpen}>
-          <div className='flex justify-between relative mx-6' >
+          <div className="flex justify-between relative mx-6">
             <div>
-              <h1 className='text-3xl mt-6 mb-9'>Add a new User</h1>
+              <h1 className="text-3xl mt-6 mb-14">Add a new User</h1>
             </div>
-            <div className='mt-8 cursor-pointer' onClick={() => { setIsAddModalOpen(false); }}>
+            <div
+              className="mt-8 cursor-pointer"
+              onClick={() => {
+                setIsAddModalOpen(false);
+              }}
+            >
               <XmarkIcon />
             </div>
           </div>
           <form onSubmit={handleSubmitUser}>
-            <div className='space-y-6 pb-5'>
+            <div className="space-y-6 pb-5">
               <div>
-                <label className='ml-6 text-sm font-bold'>Role</label>
-                <div className='mx-6'>
-                  <Select options={options} value={role} eventHandler={handleValueChange} />
+                <label className="ml-6 text-sm font-bold">Role</label>
+                <div className="mx-6">
+                  <Select
+                    options={options}
+                    value={role}
+                    eventHandler={handleValueChange}
+                  />
                 </div>
               </div>
               <div>
-                <label className='ml-6 text-sm font-bold'>First Name</label>
-                <div className='mx-6'>
-                  <InputField value={formData.firstName} eventHandler={handleChange} name="firstName" />
-                  {(errorFistName.length > 0) && <span className='text-red-500'>{errorFistName}</span>}
+                <label className="ml-6 text-sm font-bold">First Name</label>
+                <div className="mx-6">
+                  <InputField
+                    value={formData.firstName}
+                    eventHandler={handleChange}
+                    name="firstName"
+                    className={errorFistName.length > 0 ? 'border-red-500' : ''}
+                  />
+                  {errorFistName.length > 0 && (
+                    <span className="text-red-500">{errorFistName}</span>
+                  )}
                 </div>
               </div>
               <div>
-                <label className='ml-6 text-sm font-bold'>Last Name</label>
-                <div className='mx-6'>
-                  <InputField value={formData.lastName} eventHandler={handleChange} name="lastName" />
-                  {(errorLastName.length > 0) && <span className='text-red-500'>{errorLastName}</span>}
+                <label className="ml-6 text-sm font-bold">Last Name</label>
+                <div className="mx-6">
+                  <InputField
+                    value={formData.lastName}
+                    eventHandler={handleChange}
+                    name="lastName"
+                    className={errorLastName.length > 0 ? 'border-red-500' : ''}
+                  />
+                  {errorLastName.length > 0 && (
+                    <span className="text-red-500">{errorLastName}</span>
+                  )}
                 </div>
               </div>
               <div>
-                <label className='ml-6 text-sm font-bold'>Email</label>
-                <div className='mx-6'>
-                  <InputField value={formData.email} eventHandler={handleChange} name="email" />
-                  {(errorEmail.length > 0) && <span className='text-red-500'>{errorEmail}</span>}
+                <label className="ml-6 text-sm font-bold">Email</label>
+                <div className="mx-6">
+                  <InputField
+                    value={formData.email}
+                    eventHandler={handleChange}
+                    name="email"
+                    className={errorEmail.length > 0 ? 'border-red-500' : ''}
+                  />
+                  {errorEmail.length > 0 && (
+                    <span className="text-red-500">{errorEmail}</span>
+                  )}
                 </div>
               </div>
             </div>
-            <div className='flex justify-end mr-6'>
-              <Button text='Create New User' type='submit' />
+            <div className="flex justify-end mr-6">
+              <Button text="Create New User" type="submit" />
             </div>
           </form>
         </Modal>
         <Modal isOpen={isEditModalOpen}>
-          <div className='flex justify-between relative mx-6 sticky'>
+          <div className="flex justify-between relative mx-6 sticky">
             <div>
-              <h1 className='text-3xl mt-6 mb-9'>John Strong</h1>
+              <h1 className="text-3xl mt-6 mb-14">John Strong</h1>
             </div>
-            <div className='mt-8 cursor-pointer' onClick={() => { setIsEditModalOpen(false); }}>
+            <div
+              className="mt-8 cursor-pointer"
+              onClick={() => {
+                setIsEditModalOpen(false);
+              }}
+            >
               <XmarkIcon />
             </div>
           </div>
           <form onSubmit={handleSubmitEdit}>
-            <div className='space-y-6 pb-5'>
+            <div className="space-y-6 pb-5">
               <div>
-                <label className='ml-6 text-sm font-bold'>Role</label>
-                <div className='mx-6'>
-                  <Select options={options} value={role} eventHandler={handleValueChange} />
+                <label className="ml-6 text-sm font-bold">Role</label>
+                <div className="mx-6">
+                  <Select
+                    options={options}
+                    value={role}
+                    eventHandler={handleValueChange}
+                  />
                 </div>
               </div>
               <div>
-                <label className='ml-6 text-sm font-bold'>Email</label>
-                <div className='mx-6'>
-                  <InputField value={formData.email} eventHandler={handleChange} name="email" />
-                  {(errorEmail.length > 0) && <span className='text-red-500'>{errorEmail}</span>}
+                <label className="ml-6 text-sm font-bold">Email</label>
+                <div className="mx-6">
+                  <InputField
+                    value={formData.email}
+                    eventHandler={handleChange}
+                    name="email"
+                    className={errorEmail.length > 0 ? 'border-red-500' : ''}
+                  />
+                  {errorEmail.length > 0 && (
+                    <span className="text-red-500">{errorEmail}</span>
+                  )}
                 </div>
               </div>
               <div>
-                <label className='ml-6 text-sm font-bold'>First Name</label>
-                <div className='mx-6'>
-                  <InputField value={formData.firstName} eventHandler={handleChange} name="firstName" />
-                  {(errorFistName.length > 0) && <span className='text-red-500'>{errorFistName}</span>}
+                <label className="ml-6 text-sm font-bold">First Name</label>
+                <div className="mx-6">
+                  <InputField
+                    value={formData.firstName}
+                    eventHandler={handleChange}
+                    name="firstName"
+                    className={errorFistName.length > 0 ? 'border-red-500' : ''}
+                  />
+                  {errorFistName.length > 0 && (
+                    <span className="text-red-500">{errorFistName}</span>
+                  )}
                 </div>
               </div>
               <div>
-                <label className='ml-6 text-sm font-bold'>Last Name</label>
-                <div className='mx-6'>
-                  <InputField value={formData.lastName} eventHandler={handleChange} name="lastName" />
-                  {(errorLastName.length > 0) && <span className='text-red-500'>{errorLastName}</span>}
+                <label className="ml-6 text-sm font-bold">Last Name</label>
+                <div className="mx-6">
+                  <InputField
+                    value={formData.lastName}
+                    eventHandler={handleChange}
+                    name="lastName"
+                    className={errorLastName.length > 0 ? 'border-red-500' : ''}
+                  />
+                  {errorLastName.length > 0 && (
+                    <span className="text-red-500">{errorLastName}</span>
+                  )}
                 </div>
               </div>
               <div>
-                <label className='ml-6 text-sm font-bold'>Password</label>
-                <div className='mx-6'>
-                  <InputField value={formData.password} eventHandler={handleChange} name="password" type='password' />
-                  {(errorPassword.length > 0) && <span className='text-red-500'>{errorPassword}</span>}
+                <label className="ml-6 text-sm font-bold">Password</label>
+                <div className="mx-6">
+                  <InputField
+                    value={formData.password}
+                    eventHandler={handleChange}
+                    name="password"
+                    type="password"
+                    className={errorPassword.length > 0 ? 'border-red-500' : ''}
+                  />
+                  {errorPassword.length > 0 && (
+                    <span className="text-red-500">{errorPassword}</span>
+                  )}
                 </div>
               </div>
               <div>
-                <label className='ml-6 text-sm font-bold'>Confirm Password</label>
-                <div className='mx-6'>
-                  <InputField value={formData.confirmPassword} eventHandler={handleChange} name="confirmPassword" type='password' />
-                  {(confirmPassword.length > 0) && <span className='text-red-500'>{confirmPassword}</span>}
+                <label className="ml-6 text-sm font-bold">
+                  Confirm Password
+                </label>
+                <div className="mx-6">
+                  <InputField
+                    value={formData.confirmPassword}
+                    eventHandler={handleChange}
+                    name="confirmPassword"
+                    type="password"
+                    className={confirmPassword.length > 0 ? 'border-red-500' : ''}
+                  />
+                  {confirmPassword.length > 0 && (
+                    <span className="text-red-500">{confirmPassword}</span>
+                  )}
                 </div>
               </div>
             </div>
-            <div className='flex justify-between mx-6'>
-              <Button text='Delete User' color='red' hover='hover:bg-red-600' onClick={handleDeleteUser} />
-              <Button text='Update User' hover='hover:bg-blue-700' type='submit' />
+            <div className="flex justify-between mx-6">
+              <Button
+                text="Delete User"
+                color="bg-red-500"
+                hover="hover:bg-red-600"
+                onClick={handleDeleteUser}
+              />
+              <Button
+                text="Update User"
+                hover="hover:bg-blue-700"
+                type="submit"
+              />
             </div>
           </form>
         </Modal>
         <Modal isOpen={isConfirmationModalOpen}>
-          <div className='flex justify-between relative mr-6'>
+          <div className="flex justify-between relative mr-6">
             <div>
-              <h1 className='text-3xl mt-6 ml-6 mb-14'>Confirmation</h1>
+              <h1 className="text-3xl mt-6 ml-6 mb-14">Confirmation</h1>
             </div>
-            <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsConfirmationModalOpen(false); }}>
+            <div
+              className="mt-8 mr-4 cursor-pointer"
+              onClick={() => {
+                setIsConfirmationModalOpen(false);
+              }}
+            >
               <XmarkIcon />
             </div>
           </div>
-          <div className='text-lg px-6 pb-10'>{confirmationMessage}</div>
-          <div className='flex justify-between mx-6'>
-            <Button text='Cancel' color='red' hover='hover:bg-red-600' onClick={() => { setIsConfirmationModalOpen(false); }} />
-            <Button text='Confirm' hover='hover:bg-blue-700' onClick={handleConfirm} />
+          <div className="text-lg px-6 pb-10">{confirmationMessage}</div>
+          <div className="flex justify-between mx-6">
+            <Button
+              text="Cancel"
+              color="bg-red-500"
+              hover="hover:bg-red-600"
+              onClick={() => {
+                setIsConfirmationModalOpen(false);
+              }}
+            />
+            <Button
+              text="Confirm"
+              hover="hover:bg-blue-700"
+              onClick={handleConfirm}
+            />
           </div>
         </Modal>
       </div>

--- a/client/src/pages/users/[company_id]/list/index.tsx
+++ b/client/src/pages/users/[company_id]/list/index.tsx
@@ -69,6 +69,15 @@ const UsersList: React.FC = () => {
     if (formData.firstName.length === 0 || formData.lastName.length === 0 || formData.email.length === 0) {
       errorMessages = 'Please fill in all required fields.';
     }
+    if (
+      formData.firstName.length < 3 ||
+      formData.lastName.length < 3) {
+      errorMessages = 'The First and Last name should be more than 2 characters';
+    }
+    const emailRegex = /^\S+@\S+\.\S+$/;
+    if (!emailRegex.test(formData.email)) {
+      errorMessages = 'Invalid Email Address';
+    }
     if (errorMessages.length > 0) {
       setValidation(errorMessages);
     } else {
@@ -84,6 +93,20 @@ const UsersList: React.FC = () => {
     let errorMessages = '';
     if (formData.firstName.length === 0 || formData.lastName.length === 0 || formData.email.length === 0) {
       errorMessages = 'Please fill in all required fields.';
+    }
+    const emailRegex = /^\S+@\S+\.\S+$/;
+    if (!emailRegex.test(formData.email)) {
+      errorMessages = 'Invalid email address';
+    }
+    if (
+      formData.firstName.length < 2 ||
+      formData.lastName.length < 2) {
+      errorMessages = 'The First and Last name should be more than 2 characters';
+    }
+    if (
+      formData.password.length < 5 ||
+      formData.confirmPassword.length < 5) {
+      errorMessages = 'Password should be more than 5 characters';
     }
     if (formData.password !== formData.confirmPassword) {
       errorMessages = 'Passwords do not match.';
@@ -119,11 +142,11 @@ const UsersList: React.FC = () => {
         </div>
       </div>
       <Modal isOpen={isAddModalOpen}>
-        <div className='flex justify-between relative mr-6'>
+        <div className='flex justify-between relative mx-6'>
           <div>
-            <h1 className='text-3xl mt-6 ml-6 mb-14'>Add a new User</h1>
+            <h1 className='text-3xl mt-6 mb-14'>Add a new User</h1>
           </div>
-          <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsAddModalOpen(false); }}>
+          <div className='mt-8 cursor-pointer' onClick={() => { setIsAddModalOpen(false); }}>
             <XmarkIcon />
           </div>
         </div>
@@ -161,11 +184,11 @@ const UsersList: React.FC = () => {
         </form>
       </Modal>
       <Modal isOpen={isEditModalOpen}>
-        <div className='flex justify-between relative mr-6'>
+        <div className='flex justify-between relative mx-6'>
           <div>
-            <h1 className='text-3xl mt-6 ml-6 mb-14'>John Strong</h1>
+            <h1 className='text-3xl mt-6 mb-14'>John Strong</h1>
           </div>
-          <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsEditModalOpen(false); }}>
+          <div className='mt-8 cursor-pointer' onClick={() => { setIsEditModalOpen(false); }}>
             <XmarkIcon />
           </div>
         </div>

--- a/client/src/pages/users/[company_id]/list/index.tsx
+++ b/client/src/pages/users/[company_id]/list/index.tsx
@@ -1,10 +1,11 @@
+import { Fragment, useState } from 'react';
+
 import Button from '@/src/shared/components/Button';
 import InputField from '@/src/shared/components/InputField';
 import Modal from '@/src/shared/components/Modal/Modal';
 import Select, { type SelectOptionData } from '@/src/shared/components/Select';
 import EditIcon from '@/src/shared/icons/EditIcon';
 import XmarkIcon from '@/src/shared/icons/XmarkIcon';
-import { Fragment, useState } from 'react';
 
 const UsersList: React.FC = () => {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
@@ -68,13 +69,10 @@ const UsersList: React.FC = () => {
     if (formData.firstName.length === 0 || formData.lastName.length === 0 || formData.email.length === 0) {
       errorMessages = 'Please fill in all required fields.';
     }
-    if (formData.password !== formData.confirmPassword) {
-      errorMessages = 'Passwords do not match.';
-    }
     if (errorMessages.length > 0) {
       setValidation(errorMessages);
     } else {
-    // TODO: Implement form submission logic here
+      // TODO: Implement form submission logic here
       setIsConfirmationModalOpen(true);
       setConfirmationMessage('Are you sure you want to create user?'); // Open the confirmation modal
       setValidation(''); // Clear validation error message
@@ -108,131 +106,131 @@ const UsersList: React.FC = () => {
   };
 
   const handleDeleteUser = (): void => {
-  // TODO: Implement delete operation here
+    // TODO: Implement delete operation here
     setIsConfirmationModalOpen(true); // Open the confirmation modal
     setConfirmationMessage('Are you sure you want to delete user?'); // Set the confirmation message
   };
 
   return (
     <Fragment>
-        <div className='ml-12 mb-12'>
-            <Button text='Add User' color='blue' width='20' onClick={handleOpenAddModal}/>
-            <div onClick={handleOpenEditModal} className='cursor-pointer'>
-            <EditIcon/>
-            </div>
+      <div className='ml-12 mb-12'>
+        <Button text='Add User' color='blue' width='20' onClick={handleOpenAddModal} />
+        <div onClick={handleOpenEditModal} className='cursor-pointer'>
+          <EditIcon />
         </div>
-        <Modal isOpen={isAddModalOpen}>
+      </div>
+      <Modal isOpen={isAddModalOpen}>
         <div className='flex justify-between relative mr-6'>
-    <div>
-      <h1 className='text-3xl mt-6 ml-6 mb-14'>Add a new User</h1>
-      </div>
-      <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsAddModalOpen(false); }}>
-      <XmarkIcon />
-      </div>
-    </div>
-          <form onSubmit={handleSubmitUser}>
+          <div>
+            <h1 className='text-3xl mt-6 ml-6 mb-14'>Add a new User</h1>
+          </div>
+          <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsAddModalOpen(false); }}>
+            <XmarkIcon />
+          </div>
+        </div>
+        <form onSubmit={handleSubmitUser}>
           <div className='space-y-6 pb-5'>
-          <div>
-            <label className='ml-6 text-sm font-bold'>Role</label>
-            <div className='mx-6'>
-            <Select options={options} value={role} eventHandler={handleValueChange}/>
+            <div>
+              <label className='ml-6 text-sm font-bold'>Role</label>
+              <div className='mx-6'>
+                <Select options={options} value={role} eventHandler={handleValueChange} />
+              </div>
             </div>
-          </div>
-          <div>
-            <label className='ml-6 text-sm font-bold'>First Name</label>
-            <div className='mx-6'>
-            <InputField value= {formData.firstName} eventHandler={handleChange} name="firstName"/>
+            <div>
+              <label className='ml-6 text-sm font-bold'>First Name</label>
+              <div className='mx-6'>
+                <InputField value={formData.firstName} eventHandler={handleChange} name="firstName" />
+              </div>
             </div>
-          </div>
-          <div>
-            <label className='ml-6 text-sm font-bold'>Last Name</label>
-            <div className='mx-6'>
-            <InputField value={formData.lastName} eventHandler={handleChange} name="lastName"/>
+            <div>
+              <label className='ml-6 text-sm font-bold'>Last Name</label>
+              <div className='mx-6'>
+                <InputField value={formData.lastName} eventHandler={handleChange} name="lastName" />
+              </div>
             </div>
-          </div>
-          <div>
-            <label className='ml-6 text-sm font-bold'>Email</label>
-            <div className='mx-6'>
-            <InputField value={formData.email} eventHandler={handleChange} name="email"/>
+            <div>
+              <label className='ml-6 text-sm font-bold'>Email</label>
+              <div className='mx-6'>
+                <InputField value={formData.email} eventHandler={handleChange} name="email" />
+              </div>
             </div>
-          </div>
-          {(validation.length > 0) && <p className='text-red-500 ml-6 mb-6'>{validation}</p>}
+            {(validation.length > 0) && <p className='text-red-500 ml-6 mb-6'>{validation}</p>}
           </div>
           <div className='flex justify-end mr-6'>
-      <Button text='Create New User' color='blue' type='submit'/>
-    </div>
-    </form>
-        </Modal>
-        <Modal isOpen={isEditModalOpen}>
+            <Button text='Create New User' color='blue' type='submit' />
+          </div>
+        </form>
+      </Modal>
+      <Modal isOpen={isEditModalOpen}>
         <div className='flex justify-between relative mr-6'>
-    <div>
-      <h1 className='text-3xl mt-6 ml-6 mb-14'>John Strong</h1>
-      </div>
-      <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsEditModalOpen(false); }}>
-      <XmarkIcon />
-      </div>
-    </div>
-          <form onSubmit={handleSubmitEdit}>
+          <div>
+            <h1 className='text-3xl mt-6 ml-6 mb-14'>John Strong</h1>
+          </div>
+          <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsEditModalOpen(false); }}>
+            <XmarkIcon />
+          </div>
+        </div>
+        <form onSubmit={handleSubmitEdit}>
           <div className='space-y-6 pb-5'>
-          <div>
-            <label className='ml-6 text-sm font-bold'>Role</label>
-            <div className='mx-6'>
-            <Select options={options} value={role} eventHandler={handleValueChange}/>
+            <div>
+              <label className='ml-6 text-sm font-bold'>Role</label>
+              <div className='mx-6'>
+                <Select options={options} value={role} eventHandler={handleValueChange} />
+              </div>
             </div>
-          </div>
-          <div>
-            <label className='ml-6 text-sm font-bold'>Email</label>
-            <div className='mx-6'>
-            <InputField value={formData.email} eventHandler={handleChange} name="email"/>
+            <div>
+              <label className='ml-6 text-sm font-bold'>Email</label>
+              <div className='mx-6'>
+                <InputField value={formData.email} eventHandler={handleChange} name="email" />
+              </div>
             </div>
-          </div>
-          <div>
-            <label className='ml-6 text-sm font-bold'>First Name</label>
-            <div className='mx-6'>
-            <InputField value= {formData.firstName} eventHandler={handleChange} name="firstName"/>
+            <div>
+              <label className='ml-6 text-sm font-bold'>First Name</label>
+              <div className='mx-6'>
+                <InputField value={formData.firstName} eventHandler={handleChange} name="firstName" />
+              </div>
             </div>
-          </div>
-          <div>
-            <label className='ml-6 text-sm font-bold'>Last Name</label>
-            <div className='mx-6'>
-            <InputField value={formData.lastName} eventHandler={handleChange} name="lastName"/>
+            <div>
+              <label className='ml-6 text-sm font-bold'>Last Name</label>
+              <div className='mx-6'>
+                <InputField value={formData.lastName} eventHandler={handleChange} name="lastName" />
+              </div>
             </div>
-          </div>
-          <div>
-            <label className='ml-6 text-sm font-bold'>Password</label>
-            <div className='mx-6'>
-            <InputField value={formData.password} eventHandler={handleChange} name="password" type='password'/>
+            <div>
+              <label className='ml-6 text-sm font-bold'>Password</label>
+              <div className='mx-6'>
+                <InputField value={formData.password} eventHandler={handleChange} name="password" type='password' />
+              </div>
             </div>
-          </div>
-          <div>
-            <label className='ml-6 text-sm font-bold'>Confirm Password</label>
-            <div className='mx-6'>
-            <InputField value={formData.confirmPassword} eventHandler={handleChange} name="confirmPassword" type='password'/>
+            <div>
+              <label className='ml-6 text-sm font-bold'>Confirm Password</label>
+              <div className='mx-6'>
+                <InputField value={formData.confirmPassword} eventHandler={handleChange} name="confirmPassword" type='password' />
+              </div>
             </div>
-          </div>
-          {(validation.length > 0) && <p className='text-red-500 ml-6 mb-6'>{validation}</p>}
+            {(validation.length > 0) && <p className='text-red-500 ml-6 mb-6'>{validation}</p>}
           </div>
           <div className='flex justify-between mx-6'>
-            <Button text='Delete User' color='red' onClick={handleDeleteUser}/>
-      <Button text='Update User' color='blue' type='submit'/>
-    </div>
-    </form>
-        </Modal>
-        <Modal isOpen={isConfirmationModalOpen}>
-  <div className='flex justify-between relative mr-6'>
-    <div>
-      <h1 className='text-3xl mt-6 ml-6 mb-14'>Confirmation</h1>
-    </div>
-    <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsConfirmationModalOpen(false); }}>
-      <XmarkIcon />
-    </div>
-  </div>
-  <div className='text-lg px-6 pb-6'>{confirmationMessage}</div>
-  <div className='flex justify-end mr-6'>
-    <Button text='Confirm' color='blue' onClick={handleConfirm}/>
-  </div>
-</Modal>
-        </Fragment>
+            <Button text='Delete User' color='red' onClick={handleDeleteUser} />
+            <Button text='Update User' color='blue' type='submit' />
+          </div>
+        </form>
+      </Modal>
+      <Modal isOpen={isConfirmationModalOpen}>
+        <div className='flex justify-between relative mr-6'>
+          <div>
+            <h1 className='text-3xl mt-6 ml-6 mb-14'>Confirmation</h1>
+          </div>
+          <div className='mt-8 mr-4 cursor-pointer' onClick={() => { setIsConfirmationModalOpen(false); }}>
+            <XmarkIcon />
+          </div>
+        </div>
+        <div className='text-lg px-6 pb-6'>{confirmationMessage}</div>
+        <div className='flex justify-end mr-6'>
+          <Button text='Confirm' color='blue' onClick={handleConfirm} />
+        </div>
+      </Modal>
+    </Fragment>
   );
 };
 

--- a/client/src/shared/components/Button/index.tsx
+++ b/client/src/shared/components/Button/index.tsx
@@ -22,7 +22,7 @@ const Button: React.FunctionComponent<ButtonProps> = ({
   return (
     <div className="flex flex-row">
       <button
-        className={`mb-4 text-white font-bold py-2 px-2 rounded border bg-${color}-500 ${hover} ${width}`}
+        className={`mb-4 text-white font-bold py-2 px-3 rounded border bg-${color}-500 ${hover} ${width}`}
         onClick={onClick}
         type={type}
       >

--- a/client/src/shared/components/Button/index.tsx
+++ b/client/src/shared/components/Button/index.tsx
@@ -8,6 +8,7 @@ export interface ButtonProps {
   width?: string;
   onClick?: () => void;
   type?: 'button' | 'submit';
+  hover?: string;
 }
 
 const Button: React.FunctionComponent<ButtonProps> = ({
@@ -15,18 +16,13 @@ const Button: React.FunctionComponent<ButtonProps> = ({
   color,
   width,
   onClick,
-  type
+  type,
+  hover
 }: ButtonProps) => {
-  const propStyle = {
-    backgroundColor: color,
-    width: width
-  };
-
   return (
     <div className="flex flex-row">
       <button
-        className="mb-4 text-white font-bold py-2 px-4 rounded border"
-        style={propStyle}
+        className={`mb-4 text-white font-bold py-2 px-2 rounded border bg-${color}-500 ${hover} ${width}`}
         onClick={onClick}
         type={type}
       >
@@ -37,10 +33,11 @@ const Button: React.FunctionComponent<ButtonProps> = ({
 };
 
 Button.defaultProps = {
-  color: '',
-  width: 'auto',
+  color: 'blue',
+  width: 'w-auto',
   onClick: () => {},
-  type: 'button'
+  type: 'button',
+  hover: ''
 };
 
 export default Button;

--- a/client/src/shared/components/Button/index.tsx
+++ b/client/src/shared/components/Button/index.tsx
@@ -22,7 +22,7 @@ const Button: React.FunctionComponent<ButtonProps> = ({
   return (
     <div className="flex flex-row">
       <button
-        className={`mb-4 text-white font-bold py-2 px-3 rounded border bg-${color}-500 ${hover} ${width}`}
+        className={`mb-4 text-white font-bold py-2 px-3 rounded border ${color} ${hover} ${width}`}
         onClick={onClick}
         type={type}
       >
@@ -33,7 +33,7 @@ const Button: React.FunctionComponent<ButtonProps> = ({
 };
 
 Button.defaultProps = {
-  color: 'blue',
+  color: 'bg-blue-500',
   width: 'w-auto',
   onClick: () => {},
   type: 'button',

--- a/client/src/shared/components/InputField/index.tsx
+++ b/client/src/shared/components/InputField/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
 /* eslint-disable object-shorthand */
 import React from 'react';
 
@@ -11,6 +12,7 @@ export interface InputFieldProps {
   name?: string;
   value?: string;
   eventHandler?: (...args: any[]) => any;
+  className?: string;
 }
 
 const InputField: React.FC<InputFieldProps> = ({
@@ -22,7 +24,8 @@ const InputField: React.FC<InputFieldProps> = ({
   height,
   name,
   value,
-  eventHandler
+  eventHandler,
+  className
 }: InputFieldProps) => {
   const propStyle = {
     width: width,
@@ -40,7 +43,7 @@ const InputField: React.FC<InputFieldProps> = ({
         </label>
       )}
       <input
-        className="appearance-none border border-gray-300 rounded text-sm py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        className={`appearance-none border border-gray-300 rounded text-sm py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline ${className}`}
         style={propStyle}
         id={id}
         type={type}
@@ -60,7 +63,8 @@ InputField.defaultProps = {
   id: '',
   width: '100%',
   height: '',
-  value: ''
+  value: '',
+  className: ''
 };
 
 export default InputField;

--- a/client/src/shared/components/InputField/index.tsx
+++ b/client/src/shared/components/InputField/index.tsx
@@ -40,7 +40,7 @@ const InputField: React.FC<InputFieldProps> = ({
         </label>
       )}
       <input
-        className="shadow appearance-none border rounded text-lg py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        className="appearance-none border border-gray-300 rounded text-lg py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
         style={propStyle}
         id={id}
         type={type}

--- a/client/src/shared/components/InputField/index.tsx
+++ b/client/src/shared/components/InputField/index.tsx
@@ -40,7 +40,7 @@ const InputField: React.FC<InputFieldProps> = ({
         </label>
       )}
       <input
-        className="appearance-none border border-gray-300 rounded text-lg py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        className="appearance-none border border-gray-300 rounded text-sm py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
         style={propStyle}
         id={id}
         type={type}

--- a/client/src/shared/components/Modal/Modal.tsx
+++ b/client/src/shared/components/Modal/Modal.tsx
@@ -13,28 +13,30 @@ const Modal: React.FC<ModalProps> = ({
 
   return (
     <Fragment>
-    <div className="fixed z-10 inset-0 overflow-y-auto">
-      <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-        <div className="fixed inset-0 transition-opacity">
-          <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
-        </div>
+      <div className="fixed z-10 inset-0  overflow-hidden fixed">
+        <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+          <div className="fixed inset-0 transition-opacity">
+            <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
+          </div>
 
-        <span
-          className="hidden sm:inline-block sm:align-middle sm:h-screen"
-          aria-hidden="true"
-        ></span>
+          <span
+            className="hidden sm:inline-block sm:align-middle sm:h-screen"
+            aria-hidden="true"
+          ></span>
 
-        <div
-          className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all lg:my-8 lg:align-middle w-2/4"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="modal-headline"
-        >
-          {children}
+          <div
+            className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all lg:my-8 lg:align-middle w-2/4"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="modal-headline"
+          >
+            <div className='max-h-screen overflow-y-auto'>
+              {children}
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </Fragment>
+    </Fragment>
   );
 };
 

--- a/client/src/shared/components/Modal/Modal.tsx
+++ b/client/src/shared/components/Modal/Modal.tsx
@@ -1,0 +1,41 @@
+import React, { Fragment } from 'react';
+
+export interface ModalProps {
+  children?: any
+  isOpen: boolean
+}
+
+const Modal: React.FC<ModalProps> = ({
+  children,
+  isOpen
+}: ModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <Fragment>
+    <div className="fixed z-10 inset-0 overflow-y-auto">
+      <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+        <div className="fixed inset-0 transition-opacity">
+          <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
+        </div>
+
+        <span
+          className="hidden sm:inline-block sm:align-middle sm:h-screen"
+          aria-hidden="true"
+        ></span>
+
+        <div
+          className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all lg:my-8 lg:align-middle w-2/4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="modal-headline"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  </Fragment>
+  );
+};
+
+export default Modal;

--- a/client/src/shared/hooks/useEditAddUser.ts
+++ b/client/src/shared/hooks/useEditAddUser.ts
@@ -1,0 +1,167 @@
+import { useState } from 'react';
+
+import { type SelectOptionData } from '../components/Select';
+
+const useEditAddUser = (): any => {
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+
+  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
+
+  const [confirmationMessage, setConfirmationMessage] = useState('');
+
+  const [errorFistName, setErrorFistName] = useState('');
+
+  const [errorLastName, setErrorLastName] = useState('');
+
+  const [errorEmail, setErrorEmail] = useState('');
+
+  const [errorPassword, setErrorPassword] = useState('');
+
+  const [confirmPassword, setConfirmPassword] = useState('');
+
+  const handleOpenAddModal = (): void => {
+    setIsAddModalOpen(true);
+  };
+
+  const handleOpenEditModal = (): void => {
+    setIsEditModalOpen(true);
+  };
+
+  const ONE = '1';
+
+  const TWO = '2';
+
+  const THREE = '3';
+
+  const options: SelectOptionData[] = [
+    { id: 1, text: 'Admin' },
+    { id: 2, text: 'Trainer' },
+    { id: 3, text: 'Trainee' }
+  ];
+
+  const [role, setRole] = useState<typeof ONE | typeof TWO | typeof THREE>(
+    ONE
+  );
+
+  const handleValueChange = (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ): void => {
+    setRole(event.target.value as typeof ONE | typeof TWO | typeof THREE);
+  };
+
+  const [formData, setFormData] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    password: '',
+    confirmPassword: ''
+  });
+
+  const handleChange = (event: { target: { name: any; value: any; }; }): void => {
+    setFormData({
+      ...formData,
+      [event.target.name]: event.target.value
+    });
+    setErrorFistName('');
+    setErrorLastName('');
+    setErrorEmail('');
+    setErrorPassword('');
+    setConfirmPassword('');
+  };
+
+  const handleSubmitUser = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    if (formData.firstName.length === 0) {
+      setErrorFistName('First Name should not be empty');
+    }
+    if (formData.lastName.length === 0) {
+      setErrorLastName('Last Name should not be empty');
+    }
+    if (formData.email.length === 0) {
+      setErrorEmail('Email should not be empty');
+    } else
+    if (
+      formData.firstName.length === 1) {
+      setErrorFistName('First Name should be at least 2 or more characters');
+    } else
+    if (
+      formData.lastName.length === 1) {
+      setErrorLastName('Last Name should be at least 2 or more characters');
+    } else {
+      setIsConfirmationModalOpen(true);
+      setConfirmationMessage('Are you sure you want to create user?');
+    }
+  };
+
+  const handleSubmitEdit = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    if (formData.firstName.length === 0) {
+      setErrorFistName('First Name should not be empty');
+    }
+    if (formData.lastName.length === 0) {
+      setErrorLastName('Last Name should not be empty');
+    }
+    if (formData.email.length === 0) {
+      setErrorEmail('Email should not be empty');
+    }
+    if (
+      formData.firstName.length === 1) {
+      setErrorFistName('First Name should be at least 2 or more characters');
+    } else
+    if (
+      formData.lastName.length === 1) {
+      setErrorLastName('Last Name should be at least 2 or more characters');
+    } else if (
+      formData.password.length < 5) {
+      setErrorPassword('Password must be at least 5 or more characters');
+    } else
+    if (
+      formData.password !== formData.confirmPassword) {
+      setConfirmPassword('Passwords do not match');
+    } else {
+      setIsConfirmationModalOpen(true);
+      setConfirmationMessage('Are you sure you want to create user?');
+    }
+  };
+
+  const handleConfirm = (): void => {
+    setIsConfirmationModalOpen(false); // Close the confirmation modal
+    setIsEditModalOpen(false);
+    setIsAddModalOpen(false);
+  };
+
+  const handleDeleteUser = (): void => {
+    // TODO: Implement delete operation here
+    setIsConfirmationModalOpen(true); // Open the confirmation modal
+    setConfirmationMessage('Are you sure you want to delete user?'); // Set the confirmation message
+  };
+  return {
+    isAddModalOpen,
+    isEditModalOpen,
+    isConfirmationModalOpen,
+    confirmationMessage,
+    handleOpenAddModal,
+    handleOpenEditModal,
+    options,
+    role,
+    handleValueChange,
+    handleChange,
+    handleSubmitUser,
+    handleSubmitEdit,
+    handleConfirm,
+    handleDeleteUser,
+    formData,
+    setIsAddModalOpen,
+    setIsEditModalOpen,
+    setIsConfirmationModalOpen,
+    errorFistName,
+    errorLastName,
+    errorEmail,
+    errorPassword,
+    confirmPassword
+  };
+};
+
+export default useEditAddUser;

--- a/client/src/shared/icons/EditIcon.tsx
+++ b/client/src/shared/icons/EditIcon.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+import type { FC } from 'react';
+
+export interface EditIconProps {
+  classname?: string
+}
+
+const EditIcon: FC<EditIconProps> = ({ classname }: EditIconProps) => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" className={classname}>
+        <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125" />
+      </svg>
+
+  );
+};
+
+EditIcon.defaultProps = {
+  classname: 'w-6 h-6'
+};
+
+export default EditIcon;

--- a/client/src/shared/icons/XmarkIcon.tsx
+++ b/client/src/shared/icons/XmarkIcon.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+import type { FC } from 'react';
+
+export interface ListIconProps {
+  classname?: string
+}
+
+const ListIcon: FC<ListIconProps> = ({ classname }: ListIconProps) => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" className={classname}>
+  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+</svg>
+
+  );
+};
+
+ListIcon.defaultProps = {
+  classname: 'w-6 h-6'
+};
+
+export default ListIcon;


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/board/LMS?selectedIssueKey=LMS-354

## Defintion of Done
Be able to create a reusable modal for add and edit user

## Steps to reproduce
cd client
npm run dev
visit url: http://localhost:3000/users/3/list

## Affected Components / Functionalities / Page
Select, Input Field,  User's List Page, Modal Component

## Test Cases

- [x] place this in route /users/<:COMPANY_ID>/list
- [x] create a reusable modal that will accept following properties
- [x] it should be able to show "add" user modal
- [x] it should be able to show "edit" user modal
- [x] it should be able to show the same fields provided in the design
- [x] the design should be followed as closest as possible
- [x] use native . No need to follow the behavior and design in the page.
- [x] there must be a frontend validation, thus it should display error message if it has (follow same implementation in sign in page)
- [x] add validations e.g. required, minimum, maximum, etc. (check in the data dictionary)
- [x] in "edit" modal. if user click "delete user" button. It should prompt a confirmation dialog.
- [x] exclude "enable notification", "Title", "Company", "Country", "Cell", "Work Phone", "add to courses", "add to groups", "add to learning paths" select fields
- [x] exclude "send new password to user" in "edit" modal
- [x] in role dropdown show options "admin", "trainer", "trainee"

## Notes
* I added small changes to the style of input field component so that it will be same to the select component 
* I only put "All fields should be required" and "Password Do not match" validation message since it will be replaced with BE Validations
*outside click function will set aside first need to do bugfix in the useOutsideClick later


## Screenshots
![pr7](https://user-images.githubusercontent.com/110363969/228747767-4ca6c2d1-1b8a-4239-9cab-8787b6c5c52a.gif)


