### PR TITLE
[LMS-366][Refactor][FE] Class List Add Button

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.2.0",
         "react-draft-wysiwyg": "^1.15.0",
+        "react-hook-form": "^7.43.9",
         "react-icons": "^4.8.0",
         "react-modal": "^3.16.1",
         "react-toastify": "^9.1.1"
@@ -3839,6 +3840,21 @@
         "react-dom": "0.13.x || 0.14.x || ^15.0.0-0 || 15.x.x || ^16.0.0-0 || ^16.x.x || ^17.x.x || ^18.x.x"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.43.9",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.9.tgz",
+      "integrity": "sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
@@ -4605,6 +4621,20 @@
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/client/package.json
+++ b/client/package.json
@@ -16,8 +16,9 @@
     "next": "13.2.1",
     "react": "^18.2.0",
     "react-copy-to-clipboard": "^5.1.0",
-    "react-dom": "^18.2.0",
+    "react-dom": "18.2.0",
     "react-draft-wysiwyg": "^1.15.0",
+    "react-hook-form": "^7.43.9",
     "react-icons": "^4.8.0",
     "react-modal": "^3.16.1",
     "react-toastify": "^9.1.1"

--- a/client/src/pages/auth/sign-in/index.tsx
+++ b/client/src/pages/auth/sign-in/index.tsx
@@ -1,20 +1,12 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
-/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import React, { Fragment } from 'react';
 import Container from '@/src/shared/layouts/Container';
 import Navbar from '@/src/shared/components/Navbar';
 import { dropdownItems, navItems } from '../../demo/layouts/navbar';
 import { useAuthSignIn } from '@/src/shared/hooks/useAuthSignIn';
+import RFInputField from '@/src/shared/components/ReactForm/RFInputField';
+
 const SignIn: React.FC = () => {
-  const {
-    email,
-    password,
-    emailError,
-    passwordError,
-    handleSubmitEvent,
-    handleEmailChangeEvent,
-    handlePasswordChangeEvent
-  } = useAuthSignIn();
+  const { onSubmit, handleSubmit, register, errors } = useAuthSignIn();
 
   return (
     <Fragment>
@@ -26,49 +18,23 @@ const SignIn: React.FC = () => {
               Sign in
             </h1>
             <hr className="mb-5 pb-8" />
-            <form onSubmit={handleSubmitEvent}>
-              <div className="mb-4">
-                <label
-                  className="block text-gray-700 font-bold mb-2"
-                  htmlFor="email"
-                >
-                  Email
-                </label>
-                <input
-                  className={`border rounded py-2 px-3 w-full ${
-                    emailError && 'border-red-500'
-                  }`}
-                  type="email"
-                  id="email"
-                  placeholder="E-mail"
-                  value={email || ''}
-                  onChange={handleEmailChangeEvent}
-                />
-                {emailError && (
-                  <p className="text-red-500 mt-1">{emailError}</p>
-                )}
-              </div>
-              <div className="mb-4">
-                <label
-                  className="block text-gray-700 font-bold mb-2"
-                  htmlFor="password"
-                >
-                  Password
-                </label>
-                <input
-                  className={`border rounded py-2 px-3 w-full ${
-                    passwordError && 'border-red-500'
-                  }`}
-                  type="password"
-                  id="password"
-                  placeholder="Password"
-                  value={password || ''}
-                  onChange={handlePasswordChangeEvent}
-                />
-                {passwordError && (
-                  <p className="text-red-500 mt-1">{passwordError}</p>
-                )}
-              </div>
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <RFInputField
+                label="Email"
+                {...register('email', { required: true, pattern: /@/ })}
+                error={
+                  errors.email !== undefined &&
+                  'This field is required and must be an email address.'
+                }
+              />
+              <RFInputField
+                label="Password"
+                type="password"
+                {...register('password', { required: true })}
+                error={
+                  errors.password !== undefined && 'This field is required'
+                }
+              />
               <button className="w-full bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-700 mt-5">
                 Log in
               </button>

--- a/client/src/pages/classes/[company_id]/list/index.tsx
+++ b/client/src/pages/classes/[company_id]/list/index.tsx
@@ -1,0 +1,13 @@
+import AddClassModal from '@/src/sections/classes/AddClassModal';
+import React, { Fragment } from 'react';
+import type { FC } from 'react';
+
+const ClassList: FC = () => {
+  return (
+    <Fragment>
+      <AddClassModal />
+    </Fragment>
+  );
+};
+
+export default ClassList;

--- a/client/src/pages/demo/components/index.tsx
+++ b/client/src/pages/demo/components/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
 /* eslint-disable react/no-unescaped-entities */
 /* eslint @typescript-eslint/no-var-requires: "off" */
 import React, { Fragment, useState } from 'react';
@@ -15,6 +16,11 @@ import Select from '@/src/shared/components/Select';
 import Button from '@/src/shared/components/Button';
 import RadioButton from '@/src/shared/components/RadioButton';
 import Table from '@/src/shared/components/Table';
+import RFInputField from '@/src/shared/components/ReactForm/RFInputField';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+interface Inputs {
+  name: string;
+}
 
 const DemoComponent: React.FunctionComponent = () => {
   // sets up the state of the page to track user interaction
@@ -32,6 +38,18 @@ const DemoComponent: React.FunctionComponent = () => {
   const table = require('./data.json');
   const tableHeader = table.tableHeader;
   const tableData = table.tableData;
+
+  // React Hook Form
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors }
+  } = useForm<Inputs>();
+  const onSubmit: SubmitHandler<Inputs> = (data: Inputs): void => {
+    console.log(data);
+  };
+  console.log(watch('name')); // watch input value by passing the name of it
 
   return (
     <Fragment>
@@ -444,6 +462,43 @@ const DemoComponent: React.FunctionComponent = () => {
             <div className="bg-gray-300 p-[5px]">
               <p>header = (array of string)</p>
               <p>children = table data/ table body </p>
+            </div>
+          </div>
+        </div>
+        <br />
+        <hr className="w-3/4 mx-auto" />
+        <br />
+        <div className="p-4 border" id="tableList">
+          <h1>Component: React Form Input Filed (RFInputField)</h1>
+          <br />
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <RFInputField
+              label="Name"
+              {...register('name', { required: true })}
+              error={errors.name !== undefined && 'This field is required'}
+            />
+            <button className="w-full bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-700 mt-5">
+              Submit
+            </button>
+          </form>
+          <br />
+
+          <div className="mt-[5px]">
+            <h1>Props: </h1>
+
+            <div className="bg-gray-300 p-[5px]">
+              <p>label: (string)[""] ex. label="Testing"</p>
+              <p> placeholder: (string)[""] ex. placeholder="Testing"</p>
+              <p>
+                type: (string)["text"] ex. type="text | email | passwrod | etc"
+              </p>
+              <p> width: "100%" | "50px",</p>
+              <p>height: "100%" | "50px"</p>
+              <p>className:(string)[""] ex. 'bg-red-500 w-5 h-5'</p>
+              <p>
+                register: (string)[""] ex. 'bg-red-500 w-5 h-5' (in regiester,
+                it must use the proper name field and also can pass validation)
+              </p>
             </div>
           </div>
         </div>

--- a/client/src/sections/classes/AddClassModal.tsx
+++ b/client/src/sections/classes/AddClassModal.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import React, { Fragment, useState } from 'react';
+import type { FC } from 'react';
+import Button from '@/src/shared/components/Button';
+import Modal from '@/src/shared/components/Modal/Modal';
+import RFInputField from '@/src/shared/components/ReactForm/RFInputField';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { type ClassFormInputs } from '@/src/shared/utils';
+
+const AddClassModal: FC = () => {
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const handleAddClassModal = (): void => {
+    setIsAddModalOpen(!isAddModalOpen);
+  };
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<ClassFormInputs>();
+
+  const onSubmit: SubmitHandler<ClassFormInputs> = (data: any): void => {
+    console.log(data);
+  };
+
+  return (
+    <Fragment>
+      <Button text="Add Class" onClick={handleAddClassModal} />
+      <Modal isOpen={isAddModalOpen}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div className="flex justify-between m-4">
+            <h1 className="text-2xl font-bold">Create New Class</h1>
+            <Button
+              text="X"
+              onClick={handleAddClassModal}
+              color="bg-inherit"
+              textColor="text-black"
+            />
+          </div>
+
+          <div className="mx-10 mb-10">
+            <RFInputField
+              label="Class Name"
+              {...register('class', { required: true, minLength: 3 })}
+              error={
+                errors.class !== undefined &&
+                'This field is required and must have at least 3 characters'
+              }
+            />
+          </div>
+
+          <div className="flex justify-end mr-4">
+            <Button
+              text="Cancel"
+              onClick={handleAddClassModal}
+              color="bg-gray-400"
+            />
+            <Button text="Create" color="bg-blue-800" type="submit" />
+          </div>
+        </form>
+      </Modal>
+    </Fragment>
+  );
+};
+
+export default AddClassModal;

--- a/client/src/shared/components/Button/index.tsx
+++ b/client/src/shared/components/Button/index.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 export interface ButtonProps {
   text: string;
+  textColor?: string;
   color?: string;
   width?: string;
   onClick?: () => void;
@@ -13,6 +14,7 @@ export interface ButtonProps {
 
 const Button: React.FunctionComponent<ButtonProps> = ({
   text,
+  textColor,
   color,
   width,
   onClick,
@@ -22,7 +24,7 @@ const Button: React.FunctionComponent<ButtonProps> = ({
   return (
     <div className="flex flex-row">
       <button
-        className={`mb-4 text-white font-bold py-2 px-3 rounded border ${color} ${hover} ${width}`}
+        className={`mb-4 font-bold py-2 px-3 rounded mx-1 ${textColor} ${color} ${hover} ${width}`}
         onClick={onClick}
         type={type}
       >
@@ -34,6 +36,7 @@ const Button: React.FunctionComponent<ButtonProps> = ({
 
 Button.defaultProps = {
   color: 'bg-blue-500',
+  textColor: 'text-white',
   width: 'w-auto',
   onClick: () => {},
   type: 'button',

--- a/client/src/shared/components/ReactForm/RFInputField/index.tsx
+++ b/client/src/shared/components/ReactForm/RFInputField/index.tsx
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+/* eslint-disable object-shorthand */
+/* eslint-disable react/display-name */
+import React from 'react';
+import { type ForwardedRef, forwardRef, type InputHTMLAttributes } from 'react';
+import { type UseFormRegisterReturn } from 'react-hook-form';
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  placeholder?: string;
+  type?: string;
+  register?: UseFormRegisterReturn;
+  error?: string | boolean;
+  width?: string;
+  height?: string;
+  className?: string;
+}
+
+const RFInputField = forwardRef(
+  (props: Props, ref: ForwardedRef<HTMLInputElement>) => {
+    const {
+      label,
+      placeholder,
+      register,
+      error,
+      width,
+      height,
+      className,
+      type,
+      ...rest
+    } = props;
+
+    const propStyle = {
+      width: width,
+      height: height
+    };
+
+    const errorAlert = (error: string | boolean): string => {
+      return error ? ' border-red-500' : ' border-gray-300';
+    };
+
+    return (
+      <div className="mb-4">
+        {label !== '' && (
+          <label className="block text-gray-700 text-sm font-bold mb-2">
+            {label}
+          </label>
+        )}
+        <input
+          {...register}
+          {...rest}
+          ref={ref}
+          type={type}
+          className={`appearance-none border rounded text-sm py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline ${
+            error !== undefined && errorAlert(error)
+          } ${className}`}
+          style={propStyle}
+        />
+        {error !== undefined && (
+          <div className="text-red-700 rounded relative" role="alert">
+            <span className="block sm:inline text-sm">{error}</span>
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+RFInputField.defaultProps = {
+  label: '',
+  placeholder: '',
+  type: 'text',
+  id: '',
+  width: '100%',
+  height: '',
+  className: ''
+};
+
+export default RFInputField;

--- a/client/src/shared/hooks/useAuthSignIn.ts
+++ b/client/src/shared/hooks/useAuthSignIn.ts
@@ -20,8 +20,6 @@ export const useAuthSignIn = (): any => {
   const onSubmit: SubmitHandler<AuthFormInput> = async (
     data: AuthFormInput
   ): Promise<void> => {
-    console.log(data);
-
     try {
       const result = await axios.post(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}auth/sign-in`,

--- a/client/src/shared/hooks/useAuthSignIn.ts
+++ b/client/src/shared/hooks/useAuthSignIn.ts
@@ -1,72 +1,47 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-/* eslint-disable object-shorthand */
-/* eslint-disable @typescript-eslint/strict-boolean-expressions */
-import { alertError, alertSuccess } from '@/src/shared/utils';
+import { useForm, type SubmitHandler } from 'react-hook-form';
 import axios from 'axios';
+import {
+  type AuthFormInput,
+  alertError,
+  alertSuccess
+} from '@/src/shared/utils';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
 
 export const useAuthSignIn = (): any => {
   const router = useRouter();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [emailError, setEmailError] = useState<string | undefined>('');
-  const [passwordError, setPasswordError] = useState<string | undefined>('');
 
-  const handleSubmitEvent = async (
-    e: React.FormEvent<HTMLFormElement>
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<AuthFormInput>();
+
+  const onSubmit: SubmitHandler<AuthFormInput> = async (
+    data: AuthFormInput
   ): Promise<void> => {
-    e.preventDefault();
-    if (!email) {
-      setEmailError('Email cannot be empty.');
+    console.log(data);
+
+    try {
+      const result = await axios.post(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}auth/sign-in`,
+        data
+      );
+      localStorage.setItem('user_token', result.data.token);
+      localStorage.setItem('signedIn', 'true');
+      router.reload();
+      alertSuccess('Login Successful');
+    } catch (error) {
+      console.log(error);
+
+      alertError('Wrong Credentials');
     }
-    if (!password) {
-      setPasswordError('Password cannot be empty.');
-    }
-    if (email && password) {
-      const postData = {
-        email: email,
-        password: password
-      };
-
-      try {
-        const result = await axios.post(
-          `${process.env.NEXT_PUBLIC_API_BASE_URL}auth/sign-in`,
-          postData
-        );
-        localStorage.setItem('user_token', result.data.token);
-        localStorage.setItem('signedIn', 'true');
-        router.reload();
-        alertSuccess('Login Successful');
-      } catch (error) {
-        console.log(error);
-
-        alertError('Wrong Credentials');
-      }
-    }
-  };
-
-  const handleEmailChangeEvent = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ): void => {
-    setEmail(e.target.value);
-    setEmailError('');
-  };
-
-  const handlePasswordChangeEvent = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ): void => {
-    setPassword(e.target.value);
-    setPasswordError('');
   };
 
   return {
-    email,
-    password,
-    emailError,
-    passwordError,
-    handleSubmitEvent,
-    handleEmailChangeEvent,
-    handlePasswordChangeEvent
+    onSubmit,
+    handleSubmit,
+    register,
+    errors
   };
 };

--- a/client/src/shared/utils/interface.ts
+++ b/client/src/shared/utils/interface.ts
@@ -53,3 +53,12 @@ export interface User {
   created_at: string;
   updated_at: string;
 }
+
+export interface ClassFormInputs {
+  class: string;
+}
+
+export interface AuthFormInput {
+  email: string;
+  password: string;
+}


### PR DESCRIPTION
## Issue Link
[LMS-366 [Refactor][FE][Class List][Add Class Button]](https://framgiaph.backlog.com/view/LMS-366)

## Defintion of Done
* [x] create a modal
* [x] create reusable component for React Form Input Field
* [x] add the component to demo page
* [x] must have one input field "class name" and a create button
* [x] t should have validation error message
* [x] re-implement all form field related pages
* [x]  upon showing validation error messages, use react hook form

## Steps to reproduce
- Visit these pages and do necessary QA testing
 -- http://localhost:3000/demo/components
 -- http://localhost:3000/classes/1/list
 -- http://localhost:3000/auth/sign-in
 
## Affected Components / Functionalities / Page
- client/src/pages/auth/sign-in/index.tsx
- client/src/pages/demo/components/index.tsx
- client/src/shared/components/Button/index.tsx
- client/src/shared/hooks/useAuthSignIn.ts

## Test Cases
_will update soon..._

## Notes
- so far, authentication, create course, create company user, and add class are the only ones that needs Form,
- Authentication and Add Class are both using React Hook Form
- I already informed dev that handles Create Company User to align the code to my refactored code
- Create Course needs total refactor and has its own task, ill just update the task and include the necessary refactoring

## Screenshots
![RHF](https://user-images.githubusercontent.com/115448429/231384958-1a3cafb6-2190-4b83-b083-5b14815a7b27.gif)
![image](https://user-images.githubusercontent.com/115448429/231385122-5cd7d649-807e-42d4-88ee-13b878d33819.png)
![image](https://user-images.githubusercontent.com/115448429/231384463-a1420cf3-8a31-4aa6-9d63-488778414763.png)
