### PR TITLE
[LMS-368][Integration]Class List, Pagination

### DIFF
--- a/client/src/pages/classes/[company_id]/list/index.tsx
+++ b/client/src/pages/classes/[company_id]/list/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable multiline-ternary */
 import React, { Fragment } from 'react';
 import AddClassModal from '@/src/sections/classes/AddClassModal';
 import Navbar from '@/src/shared/components/Navbar';
@@ -21,7 +22,8 @@ const ClassList: FC = () => {
     startingIndex,
     numberOfUsers,
     limiter,
-    tableHeader
+    tableHeader,
+    numberOfClasses
   } = useShowClassList();
 
   const searchHandler = (searchTerm: string): void => {
@@ -61,8 +63,7 @@ const ClassList: FC = () => {
           </div>
           <div className="h-96">
             <Table header={tableHeader} checkbox={false}>
-              {numberOfUsers === 0
-                ? (
+              {numberOfUsers === 0 ? (
                 <tr>
                   <td colSpan={5} className="text-center pt-10 font-bold">
                     <div className="flex justify-center w-full">
@@ -70,9 +71,8 @@ const ClassList: FC = () => {
                     </div>
                   </td>
                 </tr>
-                  )
-                : (
-                    listOfClass.map((col: any) => (
+              ) : (
+                listOfClass.map((col: any) => (
                   <tr
                     className="border-b whitespace-nowrap text-sm text-black1 font-sans h-5"
                     key={col.id}
@@ -88,13 +88,13 @@ const ClassList: FC = () => {
                     </td>
                     <td className="px-6 py-4">{col.trainer[0].course_count}</td>
                   </tr>
-                    ))
-                  )}
+                ))
+              )}
             </Table>
             <div></div>
             <div className="flex flex-row justify-end pt-10 pb-10">
               <div className="flex items-center">
-                Showing {startingIndex} to {lastIndex} of {numberOfUsers}{' '}
+                Showing {startingIndex} to {lastIndex} of {numberOfClasses}{' '}
                 entries
               </div>
             </div>
@@ -103,8 +103,8 @@ const ClassList: FC = () => {
                 <Pagination
                   maxPages={5}
                   totalPages={Math.floor(
-                    numberOfUsers / limiter +
-                      (numberOfUsers % limiter === 0 ? 0 : 1)
+                    numberOfClasses / limiter +
+                      (numberOfClasses % limiter === 0 ? 0 : 1)
                   )}
                   currentPage={currentPage}
                   onChangePage={handleChangePageEvent}

--- a/client/src/pages/classes/[company_id]/list/index.tsx
+++ b/client/src/pages/classes/[company_id]/list/index.tsx
@@ -102,10 +102,7 @@ const ClassList: FC = () => {
               <div className="flex flex-row">
                 <Pagination
                   maxPages={5}
-                  totalPages={Math.floor(
-                    numberOfClasses / limiter +
-                      (numberOfClasses % limiter === 0 ? 0 : 1)
-                  )}
+                  totalPages={Math.ceil(numberOfClasses / limiter)}
                   currentPage={currentPage}
                   onChangePage={handleChangePageEvent}
                 />

--- a/client/src/shared/hooks/useShowClassList.ts
+++ b/client/src/shared/hooks/useShowClassList.ts
@@ -43,7 +43,7 @@ const useShowUserList = (): any => {
     setCurrentPage(1);
     setStartingIndex(1);
     setLastIndex(
-      listOfClass.length >= thisLimiter ? thisLimiter : listOfClass.length
+      numberOfClasses <= thisLimiter ? numberOfClasses : thisLimiter
     );
     setFlag(1);
     void router.push({

--- a/client/src/shared/hooks/useShowClassList.ts
+++ b/client/src/shared/hooks/useShowClassList.ts
@@ -5,13 +5,13 @@
 import API from '@/src/apis';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { type UserList } from '@/src/shared/utils';
+import { type ClassList } from '@/src/shared/utils';
 
 const useShowUserList = (): any => {
   const router = useRouter();
   const params = router.query;
-  const [listOfClass, setListOfClass] = useState<UserList[]>([]);
-  const [numberOfUsers, setNumberOfUsers] = useState(1000);
+  const [listOfClass, setListOfClass] = useState<ClassList[]>([]);
+  const [numberOfClasses, setNumberOfClasses] = useState(1000);
   const [limiter, setLimiter] = useState(10);
   const [currentPage, setCurrentPage] = useState(1);
   const [startingIndex, setStartingIndex] = useState(0);
@@ -19,30 +19,40 @@ const useShowUserList = (): any => {
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState('id');
   const [sortOrder, setSortOrder] = useState(true);
+  const [flag, setFlag] = useState(0);
 
   const handleChangePageEvent = (page: number): void => {
-    // void router.push({
-    //   pathname: router.pathname,
-    //   query: {
-    //     ...router.query,
-    //     page: page
-    //   }
-    // });
-    // setCurrentPage(page);
-    // setStartingIndex(limiter * page - limiter + 1);
-    // setLastIndex(limiter * page);
+    setCurrentPage(page);
+    setStartingIndex(limiter * page - limiter + 1);
+    setLastIndex(
+      limiter * page <= numberOfClasses ? limiter * page : numberOfClasses
+    );
+    setFlag(1);
+    void router.push({
+      pathname: router.pathname,
+      query: {
+        ...router.query,
+        page: page
+      }
+    });
   };
 
   const handleShowPerPage = (e: any): void => {
-    // const thisLimiter = e.target.value;
-    // setLimiter(thisLimiter);
-    // void router.push({
-    //   pathname: router.pathname,
-    //   query: {
-    //     ...router.query,
-    //     page_size: thisLimiter
-    //   }
-    // });
+    const thisLimiter = e.target.value;
+    setLimiter(thisLimiter);
+    setCurrentPage(1);
+    setStartingIndex(1);
+    setLastIndex(
+      listOfClass.length >= thisLimiter ? thisLimiter : listOfClass.length
+    );
+    setFlag(1);
+    void router.push({
+      pathname: router.pathname,
+      query: {
+        ...router.query,
+        page_size: thisLimiter
+      }
+    });
   };
   const searchHandler = (searchTerm: string): void => {
     // setSearchTerm(searchTerm);
@@ -78,13 +88,13 @@ const useShowUserList = (): any => {
       queryParams.sort_order = sortOrder ? 'asc' : 'desc';
     }
 
-    // if (limiter !== 0) {
-    //   queryParams.page_size = limiter;
-    // }
+    if (limiter !== 0) {
+      queryParams.page_size = limiter;
+    }
 
-    // if (currentPage !== 0) {
-    //   queryParams.page = currentPage;
-    // }
+    if (currentPage !== 0) {
+      queryParams.page = currentPage;
+    }
 
     // if (searchTerm !== '') {
     //   queryParams.search = searchTerm;
@@ -98,21 +108,34 @@ const useShowUserList = (): any => {
           params: queryParams
         });
         setListOfClass(response.data);
-
-        // uncomment this if you are working with pagination
-        // setNumberOfUsers(response.data.pagination.count);
+        if (flag === 0) {
+          const classes = await API.get(`classes/${params.company_id}`);
+          setNumberOfClasses(classes.data.length);
+          setStartingIndex(1);
+          setLastIndex(numberOfClasses >= limiter ? limiter : numberOfClasses);
+        }
       } catch (error) {
         console.error(error);
       }
     };
     void fetchdata();
-  }, [params, sortBy, sortOrder, limiter, currentPage, searchTerm]);
+  }, [
+    params,
+    sortBy,
+    sortOrder,
+    limiter,
+    currentPage,
+    searchTerm,
+    flag,
+    numberOfClasses
+  ]);
 
   const showPerPageOption = [
+    { id: 8, text: '8' },
     { id: 10, text: '10' },
     { id: 25, text: '25' },
     { id: 50, text: '50' },
-    { id: numberOfUsers, text: `all (${numberOfUsers})` }
+    { id: numberOfClasses, text: `all (${numberOfClasses})` }
   ];
 
   const tableHeader = [
@@ -133,7 +156,7 @@ const useShowUserList = (): any => {
     currentPage,
     lastIndex,
     startingIndex,
-    numberOfUsers,
+    numberOfClasses,
     limiter,
     searchHandler,
     tableHeader


### PR DESCRIPTION
## Issue Link
[LMS-368](https://framgiaph.backlog.com/view/LMS-368)

## Defintion of Done

- [x] it should be able to fetch class list dynamically
- [x] use serializer function to implement the logics, to prevent long codes in views
- [x] pagination should work accordingly
- [x] dynamic showing of number of entries
- [x] dynamic showing per page
- [x] parameter should refelect in frontend also

## Steps to reproduce
http://localhost:3000/classes/1/list

For the postman:

localhost:8000/api/classes/1?page_size='number per page'&page='page number'

## Affected Components / Functionalities / Page
api/app_sph_lms/api/serializers.py
api/app_sph_lms/api/views.py
client/src/pages/classes/[company_id]/list/index.tsx
client/src/shared/hooks/useShowClassList.ts

## Test Cases
_will update soon..._

## Notes

- I created another fetching on the useEffect to fetch all the classesto be used in the 'Showing 1 to 10 of 20 entries part'  since the first fetching only fetched the data per page and page_size. I just used a flag to avoid calling the API again. 

## Screenshots
![image](https://user-images.githubusercontent.com/122772014/232656119-ddbfe419-3517-4925-bb58-f9823c9c134c.png)
![image](https://user-images.githubusercontent.com/122772014/232654984-1e5f4548-5968-495c-b13c-1348264e853d.png)
![image](https://user-images.githubusercontent.com/122772014/232655052-79337b8f-2250-4065-abe7-2aecaf12eeae.png)

