### PR TITLE
[LMS-375][Integration] Course List View

### DIFF
--- a/client/src/pages/fetchCourse.tsx
+++ b/client/src/pages/fetchCourse.tsx
@@ -1,0 +1,103 @@
+/* eslint-disable @typescript-eslint/prefer-optional-chain */
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
+import React, { Fragment, useState } from 'react';
+import Searchbar from '@/src/shared/components/SearchBar/SearchBar';
+import useShowCourseList from '@/src/shared/hooks/useShowCourseList';
+
+const FetchCourse: React.FC = () => {
+  const { listOfCourse, listOfCategories, searchHandler } = useShowCourseList();
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [statusFilter, setStatusFilter] = useState<
+    'active' | 'inactive' | 'all'
+  >('all');
+
+  const handleStatusFilterChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setStatusFilter(event.target.value as typeof statusFilter);
+  };
+
+  return (
+    <Fragment>
+      <div className=" flex flex-row ">
+        <div className="flex items-center pr-5 text-">Search</div>
+        <div className="flex justify-end">
+          <Searchbar onSearchEvent={searchHandler} />
+        </div>
+      </div>
+      <div>
+        <h2>List of Courses</h2>
+        {listOfCourse &&
+          listOfCourse.map((course) => (
+            <div key={course.id}>
+              <h2>{course.name}</h2>
+              <p>{course.category}</p>
+            </div>
+          ))}
+      </div>
+      <br />
+      <div>
+        <h2>List of Course Categories</h2>
+        {listOfCategories &&
+          listOfCategories.map((category) => (
+            <div key={category.id}>
+              <label>
+                <input
+                  type="checkbox"
+                  value={category.name}
+                  checked={selectedCategories.includes(category.name)}
+                  onChange={(event) => {
+                    const isChecked = event.target.checked;
+                    setSelectedCategories((prevSelectedCategories) =>
+                      isChecked
+                        ? [...prevSelectedCategories, category.name]
+                        : prevSelectedCategories.filter(
+                            (name) => name !== category.name
+                          )
+                    );
+                  }}
+                />
+                {category.name}
+              </label>
+            </div>
+          ))}
+      </div>
+      <br />
+      <div>
+        <h2>Course Status</h2>
+        <label>
+          <input
+            type="radio"
+            name="status-filter"
+            value="all"
+            checked={statusFilter === 'all'}
+            onChange={handleStatusFilterChange}
+          />
+          All
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="status-filter"
+            value="active"
+            checked={statusFilter === 'active'}
+            onChange={handleStatusFilterChange}
+          />
+          Active
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="status-filter"
+            value="inactive"
+            checked={statusFilter === 'inactive'}
+            onChange={handleStatusFilterChange}
+          />
+          Inactive
+        </label>
+      </div>
+    </Fragment>
+  );
+};
+
+export default FetchCourse;

--- a/client/src/pages/trainer/courses/list/index.tsx
+++ b/client/src/pages/trainer/courses/list/index.tsx
@@ -10,6 +10,11 @@ import SearchBar from '@/src/shared/components/SearchBar/SearchBar';
 import { type Course } from '@/src/shared/utils';
 import useSortByCourse from '@/src/shared/hooks/useSortByCourse';
 import Select from '@/src/shared/components/Select';
+import Navbar from '@/src/shared/components/Navbar';
+import { dropdownItems, navItems } from '@/src/shared/utils/navBarList';
+import Breadcrumbs from '@/src/shared/components/Breadcrumbs';
+import useShowCourseList from '@/src/shared/hooks/useShowCourseList';
+import Container from '@/src/shared/layouts/Container';
 
 export interface TypeOfViewProps {
   typeOfView: string;
@@ -25,6 +30,7 @@ export interface CourseProps {
 }
 
 const View = (): ReactNode => {
+  const { paths } = useShowCourseList();
   const { setData, data, handleSortDirectionChange, options, sortDirection } =
     useSortByCourse();
 
@@ -67,8 +73,10 @@ const View = (): ReactNode => {
 
   return (
     <Fragment>
+      <Navbar navItems={navItems} dropdownItems={dropdownItems} />
       <div className="flex flex-row">
         <div className="bg-white top-0 bottom-0 w-3/5 left-20 ml-28 pr-10">
+          <Breadcrumbs paths={paths} />
           <div className="text-xl pl-5 pt-20 text-blue-500">Courses</div>
           <div className="pl-5 pt-10">
             <SearchBar onSearchEvent={handleOnSearchEvent} />

--- a/client/src/shared/hooks/useShowCourseList.ts
+++ b/client/src/shared/hooks/useShowCourseList.ts
@@ -1,0 +1,85 @@
+/* eslint-disable @typescript-eslint/no-confusing-void-expression */
+/* eslint-disable object-shorthand */
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+import API from '@/src/apis';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { type CourseList } from '@/src/shared/utils';
+
+const useShowCourseList = (): any => {
+  const router = useRouter();
+  const params = router.query;
+  const [listOfCourse, setListOfCourse] = useState<CourseList[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [sortBy, setSortBy] = useState('id');
+  const [sortOrder, setSortOrder] = useState(true);
+  const [listOfCategories, setListOfCategories] = useState<string[]>([]);
+
+  const searchHandler = (searchTerm: string): void => {
+    setSearchTerm(searchTerm);
+
+    void router.push({
+      pathname: router.pathname,
+      query: {
+        ...router.query,
+        search: searchTerm
+      }
+    });
+  };
+
+  const handleSortBy = (attribute: string): void => {
+    const newSortOrder = sortBy === attribute ? !sortOrder : true;
+    setSortBy(attribute);
+    setSortOrder(newSortOrder);
+
+    void router.push({
+      pathname: router.pathname,
+      query: {
+        ...router.query,
+        sort_by: attribute,
+        sort_order: newSortOrder ? 'asc' : 'desc'
+      }
+    });
+  };
+
+  useEffect(() => {
+    const queryParams: any = {};
+
+    if (sortBy !== 'id') {
+      queryParams.sort_by = sortBy;
+      queryParams.sort_order = sortOrder ? 'asc' : 'desc';
+    }
+
+    if (searchTerm !== '') {
+      queryParams.search = searchTerm;
+    }
+
+    setListOfCourse([]);
+
+    const fetchData = async (): Promise<void> => {
+      try {
+        const [coursesResponse, categoriesResponse] = await Promise.all([
+          API.get('/course', {
+            params: queryParams
+          }),
+          API.get('/category')
+        ]);
+        setListOfCourse(coursesResponse.data);
+        setListOfCategories(categoriesResponse.data);
+        console.log(coursesResponse.data);
+        // console.log(categoriesResponse.data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    void fetchData();
+  }, [params, sortBy, sortOrder, searchTerm]);
+
+  return {
+    listOfCourse,
+    listOfCategories,
+    searchHandler,
+    handleSortBy
+  };
+};
+export default useShowCourseList;

--- a/client/src/shared/hooks/useShowCourseList.ts
+++ b/client/src/shared/hooks/useShowCourseList.ts
@@ -15,6 +15,17 @@ const useShowCourseList = (): any => {
   const [sortOrder, setSortOrder] = useState(true);
   const [listOfCategories, setListOfCategories] = useState<string[]>([]);
 
+  const paths = [
+    {
+      text: 'Courses',
+      url: '/courses'
+    },
+    {
+      text: 'List',
+      url: router.asPath
+    }
+  ];
+
   const searchHandler = (searchTerm: string): void => {
     setSearchTerm(searchTerm);
 
@@ -79,7 +90,8 @@ const useShowCourseList = (): any => {
     listOfCourse,
     listOfCategories,
     searchHandler,
-    handleSortBy
+    handleSortBy,
+    paths
   };
 };
 export default useShowCourseList;

--- a/client/src/shared/utils/interface.ts
+++ b/client/src/shared/utils/interface.ts
@@ -47,6 +47,12 @@ export interface ClassList {
   number_of_trainees: number;
   number_of_courses: number;
 }
+export interface CourseList {
+  category: string;
+  name: string;
+  description: string;
+  created_at: Date;
+}
 
 export interface User {
   id: string;


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/LMS-375

## Defintion of Done

- [x] Fix Course List Filter APIs (filter by is_active, filter by courser_category, sortBy)
- [ ] Fetch correct API to fix the Request failed with status code 500 on load
- [x] Add Navbar & Breadcrumbs
- [ ] Wrap logic properly at the bottom

## Steps to reproduce
_will update soon..._

## Affected Components / Functionalities / Page
n/a

## Test Cases
_will update soon..._

## Notes
What I've done so far:

- Used the API endpoint for course categories [Backend]
- Used the API call for fetch course categories [Integration]
- Created a new API call for fetch courses [Integration]

I am trying to replicate the same logic as the previous integration

- I created a hook named useShowCourseList.ts
- In that hook, I plan to integrate the 3 filters (Search, Sort, Filter by Category/Status)
- I created a test page named fetchCourse.tsx
- In that page, I am trying to replicate the integration for all 3 filters

## Screenshots
n/a