### PR TITLE
LMS-378 - [FE] Material List, Search, Buttons

### DIFF
--- a/client/src/pages/element/material/index.tsx
+++ b/client/src/pages/element/material/index.tsx
@@ -1,12 +1,173 @@
+/* eslint-disable multiline-ternary */
 import AddMaterialModal from '@/src/sections/material/AddMaterialModal';
-import React, { Fragment } from 'react';
+import Button from '@/src/shared/components/Button';
+import Navbar from '@/src/shared/components/Navbar';
+import Pagination from '@/src/shared/components/Pagination';
+import SearchBar from '@/src/shared/components/SearchBar/SearchBar';
+import Select from '@/src/shared/components/Select';
+import Table from '@/src/shared/components/Table';
+import { ListItem } from '@/src/shared/components/Table/ListItem';
+import Container from '@/src/shared/layouts/Container';
+import { dropdownItems, navItems } from '@/src/shared/utils/navBarList';
+import { type FC, Fragment, useState } from 'react';
 
-const MaterialIndex: React.FC = () => {
+export enum MaterialHeaderEnum {
+  Name = 'name',
+  Type = 'type',
+  Category = 'material_category_name',
+  Data_Uploaded = 'created_at',
+  Last_Modified = 'updated_at',
+  Actions = 'Actions'
+}
+
+export interface ListItemI {
+  id?: number;
+  name: string;
+  type?: string;
+  description?: string;
+  directory: number;
+  material_category_name: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+const Material: FC = () => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const hanldeSearch = (): void => {
+    // This function will be moved in integration task
+  };
+
+  const headers = Object.keys(MaterialHeaderEnum).map((text) => {
+    // logic for sort goes here and be added to return object if needed
+    // NOTE that we need a reusable hook for sorting, currenlty there are alot of code repetitions in the codebase,
+    return {
+      text: text.split('_').join(' ')
+    };
+  });
+  // This function will be moved in integration task
+  const handlePagination = (page: number): void => {
+    setCurrentPage(page);
+  };
+  const selectOptions = [
+    { id: 8, text: '8' },
+    { id: 10, text: '10' },
+    { id: 25, text: '25' },
+    { id: 50, text: '50' }
+  ];
+
   return (
     <Fragment>
-      <AddMaterialModal />
+      <Navbar navItems={navItems} dropdownItems={dropdownItems} />
+      <Container>
+        <div className="flex items-center justify-between w-full mt-5">
+          <div className="text-lightBlue">
+            <h1 className="text-[2rem]">Materials</h1>
+            <h3 className="mt-2">All Materials</h3>
+          </div>
+          <div className="flex">
+            <Button
+              textColor="text-blue-500"
+              color="white border border-blue-500"
+              text="New Folder"
+            />
+            <AddMaterialModal />
+          </div>
+        </div>
+        <div>
+          <div className="my-6 flex justify-between items-center">
+            <Select divClass="!mb-0" value="8" options={selectOptions} />
+            <SearchBar onSearchEvent={hanldeSearch} placeholder="Search" />
+          </div>
+          <Table header={headers}>
+            {dummyData.length > 0 ? (
+              dummyData.map((data, index) => (
+                <ListItem<ListItemI>
+                  key={index}
+                  data={data}
+                  headerEnum={MaterialHeaderEnum}
+                  columnWithIcons={[MaterialHeaderEnum.Name]}
+                />
+              ))
+            ) : (
+              <tr>
+                <td
+                  colSpan={headers.length + 1}
+                  className="text-center pt-10 font-bold"
+                >
+                  <div className="flex justify-center w-full">
+                    No data found
+                  </div>
+                </td>
+              </tr>
+            )}
+          </Table>
+          <div className="flex justify-end my-10">
+            <div className="flex items-center">Showing 1 to 8 of 5 entries</div>
+          </div>
+          <div className="my-6 flex justify-center">
+            <Pagination
+              maxPages={8}
+              totalPages={5}
+              currentPage={currentPage}
+              onChangePage={handlePagination}
+            />
+          </div>
+        </div>
+      </Container>
     </Fragment>
   );
 };
 
-export default MaterialIndex;
+export default Material;
+
+// Its only for test purposes, Please delete this dummyData after itegration with backend
+const dummyData = [
+  {
+    id: 1,
+    name: 'name1',
+    link: 'https://youtube.com',
+    type: 'YouTube',
+    description:
+      'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Possimus, repudiandae.',
+    directory: 0,
+    material_category_name: 'material 1',
+    created_at: new Date(),
+    updated_at: new Date()
+  },
+  {
+    id: 2,
+    name: 'name',
+    link: null,
+    type: 'Folder',
+    description:
+      'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Possimus, repudiandae.',
+    directory: 0,
+    material_category_name: 'material 2',
+    created_at: new Date(),
+    updated_at: new Date()
+  },
+  {
+    id: 3,
+    name: 'name',
+    link: 'https://test.com',
+    type: 'Link',
+    description:
+      'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Possimus, repudiandae.',
+    directory: 0,
+    material_category_name: 'material 3',
+    created_at: new Date(),
+    updated_at: new Date()
+  },
+  {
+    id: 3,
+    name: 'name',
+    link: 'https:test1.com',
+    type: 'PDF',
+    description:
+      'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Possimus, repudiandae.',
+    directory: 0,
+    material_category_name: 'material 3',
+    created_at: new Date(),
+    updated_at: new Date()
+  }
+];

--- a/client/src/sections/users/usersUpdateDelete.tsx
+++ b/client/src/sections/users/usersUpdateDelete.tsx
@@ -114,7 +114,7 @@ const UserEditDelete: React.FC<UserUpdateDeleteProps> = ({ id }) => {
   return (
     <Fragment>
       <div className="cursor-pointer" onClick={handleOpenEditModal}>
-        <EditIcon classname="stroke-white"></EditIcon>
+        <EditIcon className="stroke-white"></EditIcon>
       </div>
       <Modal isOpen={isEditModalOpen}>
         <div className="flex justify-between relative mx-6 sticky">

--- a/client/src/shared/components/Dropdown/index.tsx
+++ b/client/src/shared/components/Dropdown/index.tsx
@@ -3,6 +3,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import ChevronDownIcon from '@/src/shared/icons/ChevronDownIcon';
 import { useOutsideClick } from '@/src/shared/hooks/useOutsideClick';
 import { useSignOut } from '@/src/shared/hooks/useSignOut';
+import Link from 'next/link';
 
 export interface Option {
   text: string;
@@ -79,7 +80,7 @@ const Dropdown: React.FC<DropdownProps> = ({
         >
           <div className="py-1" role="none">
             {options.map((option) => (
-              <a
+              <Link
                 key={option.url}
                 href={`${option.url}`}
                 className={`${
@@ -93,7 +94,7 @@ const Dropdown: React.FC<DropdownProps> = ({
                 }}
               >
                 {option.text}
-              </a>
+              </Link>
             ))}
             {showLogoutButtonState && (
               <button

--- a/client/src/shared/components/SearchBar/SearchBar.tsx
+++ b/client/src/shared/components/SearchBar/SearchBar.tsx
@@ -3,11 +3,13 @@ import React, { useState } from 'react';
 export interface SearchBarProps {
   height?: string;
   width?: string;
+  placeholder?: string;
   onSearchEvent: (query: string) => void;
 }
 
 const SearchBar: React.FC<SearchBarProps> = ({
-  onSearchEvent
+  onSearchEvent,
+  placeholder = ''
 }: SearchBarProps) => {
   const [searchTerm, setSearchTerm] = useState('');
 
@@ -45,6 +47,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
         onChange={(e) => {
           setSearchTerm(e.target.value);
         }}
+        placeholder={placeholder}
         className={containerClasses}
         onKeyUp={handleKeyUp}
       />

--- a/client/src/shared/components/Select/index.tsx
+++ b/client/src/shared/components/Select/index.tsx
@@ -13,6 +13,7 @@ export interface SelectProps<SelectOptionData> {
   value?: string;
   width?: string;
   height?: string;
+  divClass?: string;
   eventHandler?: (...args: any[]) => any;
 }
 
@@ -23,6 +24,7 @@ const Select: React.FC<SelectProps<SelectOptionData>> = ({
   value,
   width,
   height,
+  divClass,
   eventHandler
 }) => {
   const propStyle = {
@@ -31,7 +33,7 @@ const Select: React.FC<SelectProps<SelectOptionData>> = ({
   };
 
   return (
-    <div className="mb-4">
+    <div className={`mb-4 ${divClass ?? ''}`}>
       {label !== '' && (
         <label className="block text-gray-700 text-sm font-bold mb-2">
           {label}

--- a/client/src/shared/components/Table/HeaderTitle.tsx
+++ b/client/src/shared/components/Table/HeaderTitle.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable multiline-ternary */
+import { type FC, Fragment } from 'react';
+import { type TableHeader, TableSortEnum } from '.';
+import ChevronDown from '../../icons/ChevronDownIcon';
+
+interface HeaderTitleProps {
+  item: TableHeader;
+  index: number;
+  sort: { index: number; sortBy: TableSortEnum };
+  handleSortChange: (uid: number) => void;
+}
+
+const HeaderTitle: FC<HeaderTitleProps> = ({
+  item,
+  index,
+  sort,
+  handleSortChange
+}) => {
+  const arrowClasses =
+    sort.index === index && sort.sortBy === TableSortEnum.DESC
+      ? 'order-last'
+      : 'rotate-180 order-last';
+
+  return (
+    <Fragment>
+      {item.onClick !== null ? (
+        <button
+          type="button"
+          className="flex space-x-2"
+          onClick={() => {
+            if (item?.onClick !== null && item?.onClick !== undefined) {
+              item.onClick();
+              handleSortChange(index);
+            }
+          }}
+        >
+          <p>{item.text}</p>
+
+          <ChevronDown
+            height={4}
+            width={4}
+            className={`w-5 h-5 ${arrowClasses} ${
+              sort.index === index ? 'text-sky-900' : 'text-gray-400'
+            } `}
+          />
+        </button>
+      ) : (
+        <span>{item.text}</span>
+      )}
+    </Fragment>
+  );
+};
+
+export default HeaderTitle;

--- a/client/src/shared/components/Table/Icon.tsx
+++ b/client/src/shared/components/Table/Icon.tsx
@@ -1,0 +1,49 @@
+import { type FC } from 'react';
+import FolderIcon from '../../icons/FolderIcon';
+import LinkIcon from '../../icons/LinkIcon';
+import FileIcon from '../../icons/FileIcon';
+import VideoIcon from '../../icons/VideoIcon';
+import Image from 'next/image';
+
+const folder = ['FOLDER'];
+const link = ['LINK'];
+// const file = ['DOCS', 'PPT', 'PDF'];
+const picture = ['PNG', 'JPG'];
+const video = ['YOUTUBE'];
+
+export interface IconData {
+  link?: string;
+  type: string;
+}
+
+interface IconProps {
+  item: IconData;
+  className?: string;
+  src?: string;
+}
+
+const Icon: FC<IconProps> = ({ item, className }) => {
+  const iconType = item.type.toUpperCase();
+
+  if (folder.includes(iconType)) {
+    return <FolderIcon className={className} />;
+  } else if (link.includes(iconType)) {
+    return <LinkIcon className={className} />;
+  } else if (video.includes(iconType)) {
+    return <VideoIcon className={className} />;
+  } else if (picture.includes(iconType) && item?.link !== undefined) {
+    return (
+      <Image
+        src={item.link}
+        width={500}
+        height={500}
+        className={className}
+        alt="image"
+      />
+    );
+  } else {
+    return <FileIcon className={className} />;
+  }
+};
+
+export default Icon;

--- a/client/src/shared/components/Table/ListItem.tsx
+++ b/client/src/shared/components/Table/ListItem.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/consistent-indexed-object-style */
+import EditIcon from '../../icons/EditIcon';
+import TrashIcon from '../../icons/TrashIcon';
+import Icon, { type IconData } from './Icon';
+
+interface Data {
+  type?: string;
+}
+
+interface ListItemProps<T> {
+  data: T;
+  headerEnum: { [key: string]: string };
+  showCheckbox?: boolean;
+  columnWithIcons?: string[];
+  editable?: boolean;
+  deletable?: boolean;
+}
+
+export const ListItem: any = <T extends Data>({
+  data,
+  showCheckbox = true,
+  headerEnum,
+  columnWithIcons = [],
+  editable = true,
+  deletable = true
+}: ListItemProps<T>) => {
+  return (
+    <tr className="border-b whitespace-nowrap text-sm text-black1 font-sans h-5 hover:shadow-md group transition-all ease-out duration-200">
+      {showCheckbox && (
+        <td className="p-4">
+          <input type="checkbox" className="h-5 w-5 cursor-pointer" />
+        </td>
+      )}
+
+      {Object.values(headerEnum).map((column: string, index) => {
+        const item = data[column as keyof typeof data];
+        const instanceOfA = (object: any): object is IconData => {
+          return 'type' in object;
+        };
+
+        const showIcon = columnWithIcons.includes(column) && instanceOfA(data);
+
+        return (
+          <td key={index} className="px-6 py-4">
+            <div className="flex items-center space-x-2">
+              {showIcon && (
+                <Icon item={data} className="h-6 w-6 text-lightBlue" />
+              )}
+              {column === headerEnum.Actions && (
+                <div className="flex invisible items-center group-hover:visible">
+                  {editable && (
+                    <EditIcon className="w-5 h-5 mx-1 cursor-pointer" />
+                  )}
+                  {deletable && (
+                    <TrashIcon className="w-5 h-5 mx-1 text-red-600 cursor-pointer" />
+                  )}
+                </div>
+              )}
+              <p>
+                {item instanceof Date
+                  ? item.toLocaleDateString()
+                  : (item as string)}
+              </p>
+            </div>
+          </td>
+        );
+      })}
+    </tr>
+  );
+};

--- a/client/src/shared/components/Table/index.tsx
+++ b/client/src/shared/components/Table/index.tsx
@@ -2,8 +2,12 @@
 /* eslint-disable multiline-ternary */
 import React, { useState } from 'react';
 import type { ReactNode } from 'react';
-import ChevronDown from '../../icons/ChevronDownIcon';
+import HeaderTitle from './HeaderTitle';
 
+export enum TableSortEnum {
+  ASC,
+  DESC
+}
 export interface TableHeader {
   text: string;
   onClick?: () => void;
@@ -20,24 +24,28 @@ const Table: React.FC<TableProps> = ({
   children,
   checkbox
 }: TableProps) => {
-  const [isOpen, setIsOpen] = useState(true);
-  const [sortHead, setSortHead] = useState(-1);
-  const toggleCollapse = (sortBy: number): void => {
-    setSortHead(sortBy);
-    if (sortHead === sortBy) {
-      setIsOpen(!isOpen);
-    } else {
-      setIsOpen(false);
-    }
-  };
+  const [sort, setSort] = useState({
+    index: -1,
+    sortBy: TableSortEnum.ASC
+  });
 
-  const arrowClasses = !isOpen ? 'rotate-180 order-last' : 'order-last';
+  const handleSortChange = (uid: number): void => {
+    setSort((curr) => ({
+      index: uid,
+      sortBy:
+        curr.index === uid
+          ? curr.sortBy === TableSortEnum.ASC
+            ? TableSortEnum.DESC
+            : TableSortEnum.ASC
+          : TableSortEnum.ASC
+    }));
+  };
 
   return (
     <div className="overflow-auto flex justify-center">
       <table className="text-left text-gray-500 dark:text-gray-400 w-full">
         <thead>
-          <tr>
+          <tr className="bg-blueGray">
             {checkbox !== false && (
               <th className="p-4 ">
                 <input type="checkbox" className="h-5 w-5 hover:bg-sky-700" />
@@ -45,35 +53,17 @@ const Table: React.FC<TableProps> = ({
             )}
             {header.map((item, index) => (
               <th
-                className="px-6 py-3 w-auto  whitespace-nowrap text-sm text-lightBlue bg-blueGray"
+                className="px-4 py-3 w-auto  whitespace-nowrap text-sm text-lightBlue"
                 key={index}
               >
-                {item.onClick ? (
-                  <button
-                    type="button"
-                    className="flex"
-                    onClick={() => {
-                      if (item.onClick) {
-                        item.onClick();
-                        toggleCollapse(index);
-                      }
-                    }}
-                  >
-                    {item.text}
-                    {sortHead === index && (
-                      <ChevronDown
-                        height={4}
-                        width={4}
-                        className={`w-5 h-5 ml-2 mr-5 ${arrowClasses} `}
-                      />
-                    )}
-                  </button>
-                ) : (
-                  <span>{item.text}</span>
-                )}
+                <HeaderTitle
+                  item={item}
+                  index={index}
+                  sort={sort}
+                  handleSortChange={handleSortChange}
+                />
               </th>
             ))}
-            <th className="px-6 py-3 w-auto bg-blueGray"></th>
           </tr>
         </thead>
         <tbody>{children}</tbody>

--- a/client/src/shared/icons/EditIcon.tsx
+++ b/client/src/shared/icons/EditIcon.tsx
@@ -4,13 +4,13 @@ import type { FC } from 'react';
 export interface EditIconProps {
   height?: number;
   width?: number;
-  classname?: string;
+  className?: string;
 }
 
 const EditIcon: FC<EditIconProps> = ({
   height,
   width,
-  classname
+  className
 }: EditIconProps) => {
   return (
     <svg
@@ -19,13 +19,13 @@ const EditIcon: FC<EditIconProps> = ({
       xmlns="http://www.w3.org/2000/svg"
       fill="#325184"
       viewBox="0 0 24 24"
-      stroke-width="0.7"
+      strokeWidth="0.7"
       stroke="currentColor"
-      className={classname}
+      className={className}
     >
       <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeLinecap="round"
+        strokeLinejoin="round"
         d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125"
       />
     </svg>
@@ -35,7 +35,7 @@ const EditIcon: FC<EditIconProps> = ({
 EditIcon.defaultProps = {
   height: 25,
   width: 25,
-  classname: ''
+  className: ''
 };
 
 export default EditIcon;

--- a/client/src/shared/icons/FileIcon.tsx
+++ b/client/src/shared/icons/FileIcon.tsx
@@ -1,0 +1,35 @@
+import { type FC } from 'react';
+
+interface FileIconProps {
+  className?: string;
+}
+
+const FileIcon: FC<FileIconProps> = ({ className }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      className={className}
+      viewBox="0 0 512 512"
+    >
+      <path
+        d="M416 221.25V416a48 48 0 01-48 48H144a48 48 0 01-48-48V96a48 48 0 0148-48h98.75a32 32 0 0122.62 9.37l141.26 141.26a32 32 0 019.37 22.62z"
+        fill="none"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="32"
+      />
+      <path
+        d="M256 56v120a32 32 0 0032 32h120"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="32"
+      />
+    </svg>
+  );
+};
+
+export default FileIcon;

--- a/client/src/shared/icons/FolderIcon.tsx
+++ b/client/src/shared/icons/FolderIcon.tsx
@@ -1,0 +1,28 @@
+import { type FC } from 'react';
+
+interface FolderIconProps {
+  className?: string;
+}
+
+const FolderIcon: FC<FolderIconProps> = ({ className }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      className={className}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z"
+      />
+    </svg>
+  );
+};
+
+export default FolderIcon;

--- a/client/src/shared/icons/LinkIcon.tsx
+++ b/client/src/shared/icons/LinkIcon.tsx
@@ -1,0 +1,27 @@
+import { type FC } from 'react';
+
+interface LinkIconProps {
+  className?: string;
+}
+
+const LinkIcon: FC<LinkIconProps> = ({ className }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M15 7h3a5 5 0 0 1 5 5 5 5 0 0 1-5 5h-3m-6 0H6a5 5 0 0 1-5-5 5 5 0 0 1 5-5h3"></path>
+      <line x1="8" y1="12" x2="16" y2="12"></line>
+    </svg>
+  );
+};
+
+export default LinkIcon;

--- a/client/src/shared/icons/TrashIcon.tsx
+++ b/client/src/shared/icons/TrashIcon.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
+export interface DeleteIconProps {
+  className?: string;
+}
 
-const TrashIcon: React.FC = () => {
+const TrashIcon: React.FC<DeleteIconProps> = ({ className }) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
+      width="24"
+      height="24"
       strokeWidth={1.5}
       stroke="currentColor"
-      className="w-6 h-6"
+      className={className}
     >
       <path
         strokeLinecap="round"

--- a/client/src/shared/icons/VideoIcon.tsx
+++ b/client/src/shared/icons/VideoIcon.tsx
@@ -1,0 +1,28 @@
+import { type FC } from 'react';
+
+interface VideoIconProps {
+  className?: string;
+}
+
+const VideoIcon: FC<VideoIconProps> = ({ className }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      className={className}
+      viewBox="0 0 512 512"
+    >
+      <path
+        d="M448 256c0-106-86-192-192-192S64 150 64 256s86 192 192 192 192-86 192-192z"
+        fill="none"
+        stroke="currentColor"
+        strokeMiterlimit="10"
+        strokeWidth="32"
+      />
+      <path d="M216.32 334.44l114.45-69.14a10.89 10.89 0 000-18.6l-114.45-69.14a10.78 10.78 0 00-16.32 9.31v138.26a10.78 10.78 0 0016.32 9.31z" />
+    </svg>
+  );
+};
+
+export default VideoIcon;

--- a/client/src/shared/utils/navBarList.ts
+++ b/client/src/shared/utils/navBarList.ts
@@ -12,7 +12,7 @@ export const navItems = [
     url: '/',
     text: 'Training Elements',
     dropdownItems: [
-      { text: 'Materials', url: '/' },
+      { text: 'Materials', url: '/element/material' },
       { text: 'Studio', url: '/' },
       { text: 'Assessments', url: '/' },
       { text: 'Checklists', url: '/' },


### PR DESCRIPTION
## Issue Link
Issue: https://framgiaph.backlog.com/view/LMS-378

## Definition of Done
- [x] place this in route /element/material
- [x] should display the list of material (static)
- [x] should display searchbar (static)
- [x] should have navbar
- [x] Should display pagination and entries (static)
- [x] Linked the route with the header navbar
- [x] Edit and delete icons should show on hover 
- [x] Refactored the sort icon behaviour on FE     

## Steps to reproduce
- Visit `/element/material` page

## Affected Components / Functionalities / Page
- client/src/shared/components/Dropdown/index.tsx
- client/src/shared/components/SearchBar/SearchBar.tsx
- client/src/shared/components/Select/index.tsx
- client/src/shared/components/Table/index.tsx
- client/src/shared/icons/EditIcon.tsx
- client/src/shared/icons/TrashIcon.tsx
- client/src/shared/utils/navBarList.ts

## Notes
n/a

## Screenshots
https://user-images.githubusercontent.com/110364690/234811619-30b23ba3-2379-448e-babd-16d9475e8d77.mp4
