### PR TITLE
LMS-607-[Hotfix][Markup][Learners tab] Trainer can visit learners tab…

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -42,6 +42,7 @@
         "unnamedComponents": "arrow-function"
       }
     ],
-    "@typescript-eslint/semi": ["error", "always", { "omitLastInOneLineBlock": false }]
+    "@typescript-eslint/semi": ["error", "always", { "omitLastInOneLineBlock": false }],
+    "multiline-ternary": "off"
   }
 }

--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -3,5 +3,6 @@
   "trailingComma": "es5",
   "tabWidth": 2,
   "semi": true,
-  "printWidth": 100
+  "printWidth": 100,
+  "multilineTernary": true
 }

--- a/client/src/shared/components/Dropdown/SortDropdown/SortDropdown.tsx
+++ b/client/src/shared/components/Dropdown/SortDropdown/SortDropdown.tsx
@@ -13,13 +13,18 @@ export interface SortDropdownProps {
   onChange: (value: string) => void;
 }
 
-const SortDropdown: React.FC<SortDropdownProps> = ({ buttonText, buttonIcon, options, onChange }: SortDropdownProps) => {
+const SortDropdown: React.FC<SortDropdownProps> = ({
+  buttonText,
+  buttonIcon,
+  options,
+  onChange,
+}: SortDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedOption, setSelectedOption] = useState('');
+  const [selectedOption, setSelectedOption] = useState<SortOption | null>(null);
   const optionsCount: number = options.length - 1;
 
   const handleOptionSelect = (option: SortOption): void => {
-    setSelectedOption(option.value);
+    setSelectedOption(option);
     onChange(option.value);
     setIsOpen(false);
   };
@@ -34,7 +39,14 @@ const SortDropdown: React.FC<SortDropdownProps> = ({ buttonText, buttonIcon, opt
         }}
       >
         <span className="flex  border-gray-500 px-2 py-[2px] rounded">
-          {selectedOption || buttonText}
+          {selectedOption ? (
+            <>
+              {selectedOption.label}
+              {selectedOption.icon && <span>{selectedOption.icon}</span>}
+            </>
+          ) : (
+            buttonText
+          )}
         </span>
         <span>{buttonIcon}</span>
       </button>

--- a/client/src/shared/components/Dropdown/SortDropdown/SortDropdown.tsx
+++ b/client/src/shared/components/Dropdown/SortDropdown/SortDropdown.tsx
@@ -33,12 +33,12 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
     <div className="relative border border-gray-500 rounded-md">
       <button
         type="button"
-        className="flex items-center justify-between w-[219px] py-[3px] text-sm"
+        className="flex items-center justify-between w-[219px] text-sm"
         onClick={() => {
           setIsOpen(!isOpen);
         }}
       >
-        <span className="flex  border-gray-500 px-2 py-[2px] rounded">
+        <span className="flex  border-gray-500 text-[14px] px-2 rounded">
           {selectedOption ? (
             <>
               {selectedOption.label}

--- a/client/src/shared/icons/FilterIcon.tsx
+++ b/client/src/shared/icons/FilterIcon.tsx
@@ -8,8 +8,8 @@ const FilterIcon: React.FC<Props> = ({ className }: Props) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="30px"
-      height="30px"
+      width="25px"
+      height="25px"
       viewBox="0 0 35 20"
       fill="none"
     >


### PR DESCRIPTION
… in course detail page

## Issue Link
https://framgiaph.backlog.com/view/LMS-607

## Defintion of Done

- [x] Selecting an option is also its value.

## Steps to reproduce
redirect to: http://localhost:3000/trainer/courses/1

## Affected Components / Functionalities / Page
Added a rule on eslint and prettier:
client/.eslintrc.json
client/ . prettierrc
client/src/shared/components/Dropdown/SortDropdown/SortDropdown.tsx
## Test Cases
Check if selected option will be the dropdown text value.

## Screenshots
![image](https://github.com/framgia/sph-lms/assets/110363852/3327084b-b1f5-46d0-8655-154bc88b29e0)
![image](https://github.com/framgia/sph-lms/assets/110363852/275a6810-f5bd-4167-89ad-3967a89aa0f5)
