### PR TITLE
[LMS-634] [Markup] [Content Tab] Trainer can visit content tab in learning path detail page

### DIFF
--- a/client/src/pages/trainer/learning-paths/[id]/index.tsx
+++ b/client/src/pages/trainer/learning-paths/[id]/index.tsx
@@ -4,6 +4,7 @@ import Tab from '@/src/shared/components/Tabs/Tab';
 import Container from '@/src/shared/layouts/Container';
 import { Fragment } from 'react';
 import LearningPathLearnersSection from '@/src/sections/learning-paths/LearnersSection';
+import LearningPathContentSection from '@/src/sections/learning-paths/ContentSection';
 
 interface LearningPath {
   id: number;
@@ -37,7 +38,7 @@ const LearningPathContent: React.FC = () => {
           </div>
           <Tabs>
             <Tab title="Content">
-              <div>Learning Path Content</div>
+              <LearningPathContentSection />
             </Tab>
             <Tab title="Learners">
               <LearningPathLearnersSection />

--- a/client/src/sections/learning-paths/ContentSection/index.tsx
+++ b/client/src/sections/learning-paths/ContentSection/index.tsx
@@ -1,0 +1,39 @@
+import LearningPathCourseCard from '@/src/shared/components/Card/LearningPathCourseCard';
+import ChevronDown from '@/src/shared/icons/ChevronDownIcon';
+import React from 'react';
+
+const LearningPathContentSection = (): JSX.Element => {
+  return (
+    <div className="flex flex-col gap-4 mb-16">
+      <div className="flex flex-col gap-2">
+        <span className="text-sm text-dark font-medium">Description:</span>
+        <p className="text-sm">
+          Lorem ipsum dolor sit amet consectetur. Lectus sed interdum euismod rhoncus quis eu
+          elementum. Sapien eu faucibus nisl tristique ultricies morbi pellentesque volutpat
+          egestas. Sapien eu faucibus nisl tristique ultricies morbi pellentesque volutpat egestas.
+          Sapien eu faucibus nisl tristique ultricies morbi pellentesque volutpat egestas.
+        </p>
+      </div>
+      <div>
+        {courses.map((course, index) => (
+          <div key={course.id} className="flex flex-col items-center">
+            <LearningPathCourseCard
+              courseTitle={course.title}
+              imgPath={course.img_path}
+              lessonsCount={course.lessonsCount}
+            />
+            {courses.length - 1 !== index && <ChevronDown height={40} width={40} />}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default LearningPathContentSection;
+
+const courses = [
+  { id: 1, title: 'HTML Crash Course', img_path: '/image1.jpg', lessonsCount: 5 },
+  { id: 2, title: 'CSS Crash Course', img_path: '/image1.jpg', lessonsCount: 5 },
+  { id: 3, title: 'JavaScript Crash Course', img_path: '/image1.jpg', lessonsCount: 5 },
+];

--- a/client/src/sections/learning-paths/ContentSection/index.tsx
+++ b/client/src/sections/learning-paths/ContentSection/index.tsx
@@ -1,5 +1,6 @@
 import LearningPathCourseCard from '@/src/shared/components/Card/LearningPathCourseCard';
 import ChevronDown from '@/src/shared/icons/ChevronDownIcon';
+import type { Course } from '@/src/shared/utils';
 import React from 'react';
 
 const LearningPathContentSection = (): JSX.Element => {
@@ -17,12 +18,7 @@ const LearningPathContentSection = (): JSX.Element => {
       <div>
         {courses.map((course, index) => (
           <div key={course.id} className="flex flex-col items-center">
-            <LearningPathCourseCard
-              courseId={course.id}
-              courseTitle={course.title}
-              imgPath={course.img_path}
-              lessonsCount={course.lessonsCount}
-            />
+            <LearningPathCourseCard course={course} />
             {courses.length - 1 !== index && <ChevronDown height={40} width={40} />}
           </div>
         ))}
@@ -33,8 +29,59 @@ const LearningPathContentSection = (): JSX.Element => {
 
 export default LearningPathContentSection;
 
-const courses = [
-  { id: 1, title: 'HTML Crash Course', img_path: '/image1.jpg', lessonsCount: 5 },
-  { id: 2, title: 'CSS Crash Course', img_path: '/image1.jpg', lessonsCount: 5 },
-  { id: 3, title: 'JavaScript Crash Course', img_path: '/image1.jpg', lessonsCount: 5 },
+const courses: Course[] = [
+  {
+    id: 1,
+    name: 'HTML Crash Course',
+    img_path: '/image1.jpg',
+    lessons: [
+      {
+        id: '1',
+        link: '',
+        order: 1,
+        title: 'Section 1',
+      },
+    ],
+    categories: [],
+    description: 'Description',
+    is_active: true,
+    order: 1,
+    ratings: 5,
+  },
+  {
+    id: 2,
+    name: 'CSS Crash Course',
+    img_path: '/image1.jpg',
+    lessons: [
+      {
+        id: '1',
+        link: '',
+        order: 1,
+        title: 'Section 1',
+      },
+    ],
+    categories: [],
+    description: 'Description',
+    is_active: true,
+    order: 1,
+    ratings: 5,
+  },
+  {
+    id: 3,
+    name: 'JavaScript Crash Course',
+    img_path: '/image1.jpg',
+    lessons: [
+      {
+        id: '1',
+        link: '',
+        order: 1,
+        title: 'Section 1',
+      },
+    ],
+    categories: [],
+    description: 'Description',
+    is_active: true,
+    order: 1,
+    ratings: 5,
+  },
 ];

--- a/client/src/sections/learning-paths/ContentSection/index.tsx
+++ b/client/src/sections/learning-paths/ContentSection/index.tsx
@@ -18,6 +18,7 @@ const LearningPathContentSection = (): JSX.Element => {
         {courses.map((course, index) => (
           <div key={course.id} className="flex flex-col items-center">
             <LearningPathCourseCard
+              courseId={course.id}
               courseTitle={course.title}
               imgPath={course.img_path}
               lessonsCount={course.lessonsCount}

--- a/client/src/sections/learning-paths/create/PreviewSection.tsx
+++ b/client/src/sections/learning-paths/create/PreviewSection.tsx
@@ -22,12 +22,7 @@ const PreviewSection = (): JSX.Element => {
         {courses.length &&
           courses.map((course, index) => (
             <div key={course.id} className="flex flex-col items-center">
-              <LearningPathCourseCard
-                courseId={course.id}
-                courseTitle={course.name}
-                imgPath={course.img_path}
-                lessonsCount={5}
-              />
+              <LearningPathCourseCard course={course} />
               {index !== courses.length - 1 && <ChevronDown height={40} width={40} />}
             </div>
           ))}

--- a/client/src/sections/learning-paths/create/PreviewSection.tsx
+++ b/client/src/sections/learning-paths/create/PreviewSection.tsx
@@ -23,6 +23,7 @@ const PreviewSection = (): JSX.Element => {
           courses.map((course, index) => (
             <div key={course.id} className="flex flex-col items-center">
               <LearningPathCourseCard
+                courseId={course.id}
                 courseTitle={course.name}
                 imgPath={course.img_path}
                 lessonsCount={5}

--- a/client/src/shared/components/Card/CourseCard/index.tsx
+++ b/client/src/shared/components/Card/CourseCard/index.tsx
@@ -40,7 +40,7 @@ const CourseCard: React.FC<Props> = ({ course }: Props) => {
 
           <div className="text-sm font-semibold mb-1">Categories:</div>
           <div className="relative flex justify-between">
-            {course.categories.map((category, index) => (
+            {course.categories?.map((category, index) => (
               <span
                 className="text-xs font-semibold text-gray-400 border-2 border-gray-400 px-2 py-1 my-1 rounded-full transition-color duration-300 hover:bg-gray-50"
                 key={index}

--- a/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
+++ b/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
@@ -1,29 +1,29 @@
+import type { Course } from '@/src/shared/utils';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
 
 interface Props {
-  courseId: number;
-  courseTitle: string;
-  imgPath: string;
-  lessonsCount: number;
+  course: Course;
 }
 
-const LearningPathCourseCard = ({
-  courseId,
-  courseTitle,
-  imgPath,
-  lessonsCount,
-}: Props): JSX.Element => {
+const LearningPathCourseCard = ({ course }: Props): JSX.Element => {
+  const lessonCount = course.lessons?.length ?? 0;
   return (
-    <Link href={`/trainer/courses/${courseId}`}>
+    <Link href={`/trainer/courses/${course.id}`}>
       <div className="flex w-fit min-w-[420px] min-h-[128px] overflow-hidden bg-white border rounded-[5px] border-neutral-100">
-        <Image src={imgPath} width={150} height={150} alt={courseTitle} className="object-cover" />
+        <Image
+          src={course.img_path}
+          width={150}
+          height={150}
+          alt={course.name}
+          className="object-cover"
+        />
         <div className="w-full p-4 flex flex-col gap-2">
-          <h3>{courseTitle}</h3>
+          <h3>{course.name}</h3>
           <div className="flex flex-col text-xs">
             <span className="text-disabled">
-              {lessonsCount} {lessonsCount === 1 ? 'lesson' : 'lessons'} available
+              {lessonCount} {lessonCount === 1 ? 'lesson' : 'lessons'} available
             </span>
           </div>
         </div>

--- a/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
+++ b/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
@@ -9,8 +9,8 @@ interface Props {
 
 const LearningPathCourseCard = ({ imgPath, courseTitle, lessonsCount }: Props): JSX.Element => {
   return (
-    <div className="flex w-fit min-w-[420px] overflow-hidden bg-white border rounded-[5px] border-neutral-100">
-      <Image src={imgPath} width={150} height={150} alt={courseTitle} />
+    <div className="flex w-fit min-w-[420px] min-h-[128px] overflow-hidden bg-white border rounded-[5px] border-neutral-100">
+      <Image src={imgPath} width={150} height={150} alt={courseTitle} className="object-cover" />
       <div className="w-full p-4 flex flex-col gap-2">
         <h3>{courseTitle}</h3>
         <div className="flex flex-col text-xs">

--- a/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
+++ b/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
@@ -1,23 +1,34 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import React from 'react';
 
 interface Props {
-  imgPath: string;
+  courseId: number;
   courseTitle: string;
+  imgPath: string;
   lessonsCount: number;
 }
 
-const LearningPathCourseCard = ({ imgPath, courseTitle, lessonsCount }: Props): JSX.Element => {
+const LearningPathCourseCard = ({
+  courseId,
+  courseTitle,
+  imgPath,
+  lessonsCount,
+}: Props): JSX.Element => {
   return (
-    <div className="flex w-fit min-w-[420px] min-h-[128px] overflow-hidden bg-white border rounded-[5px] border-neutral-100">
-      <Image src={imgPath} width={150} height={150} alt={courseTitle} className="object-cover" />
-      <div className="w-full p-4 flex flex-col gap-2">
-        <h3>{courseTitle}</h3>
-        <div className="flex flex-col text-xs">
-          <span className="text-disabled">{lessonsCount} {lessonsCount === 1 ? 'lesson' : 'lessons'} available</span>
+    <Link href={`/trainer/courses/${courseId}`}>
+      <div className="flex w-fit min-w-[420px] min-h-[128px] overflow-hidden bg-white border rounded-[5px] border-neutral-100">
+        <Image src={imgPath} width={150} height={150} alt={courseTitle} className="object-cover" />
+        <div className="w-full p-4 flex flex-col gap-2">
+          <h3>{courseTitle}</h3>
+          <div className="flex flex-col text-xs">
+            <span className="text-disabled">
+              {lessonsCount} {lessonsCount === 1 ? 'lesson' : 'lessons'} available
+            </span>
+          </div>
         </div>
       </div>
-    </div>
+    </Link>
   );
 };
 


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/LMS-634

## Definition of Done
- [x] List of Courses (static) that's belong to LP
- [x] Display the LP's description

## Steps to reproduce
Go to `http://localhost:3000/trainer/learning-paths/1` [Content Tab]

## Affected Components / Functionalities / Page
n/a

## Test Cases
_will update soon..._

## Notes
n/a

## Screenshots
![image](https://github.com/framgia/sph-lms/assets/111732984/ef2480b9-ffcd-4a49-b967-339170ba66f8)
