### PR TITLE
LMS-632 - [Markup] [Settings tab] Display settings tab in learning path detail page

### DIFF
--- a/client/features/learning-path/learningPathSlice.ts
+++ b/client/features/learning-path/learningPathSlice.ts
@@ -47,10 +47,13 @@ export const learningPathSlice = createSlice({
       }
       state.values.courses = courses.map((course, index) => ({ ...course, order: index }));
     },
+    reset: (state) => {
+      state.values = initialState.values;
+    },
   },
 });
 
-export const { addCategory, deleteCourse, changeEditMode, reorderCourses, updateForm } =
+export const { addCategory, deleteCourse, changeEditMode, reorderCourses, updateForm, reset } =
   learningPathSlice.actions;
 
 export default learningPathSlice.reducer;

--- a/client/features/tab/tabSlice.ts
+++ b/client/features/tab/tabSlice.ts
@@ -21,9 +21,12 @@ export const tabSlice = createSlice({
     setIsTabValid: (state, action: PayloadAction<boolean>) => {
       state.isTabValid = action.payload;
     },
+    reset: (state) => {
+      return (state = initialState);
+    },
   },
 });
 
-export const { setActiveTab, setIsTabValid } = tabSlice.actions;
+export const { setActiveTab, setIsTabValid, reset } = tabSlice.actions;
 
 export default tabSlice.reducer;

--- a/client/src/pages/trainer/courses/index.tsx
+++ b/client/src/pages/trainer/courses/index.tsx
@@ -1,7 +1,7 @@
 import { useGetCoursesQuery } from '@/services/courseAPI';
 import Pagination from '@/src/shared/components/Pagination';
 import SearchBar from '@/src/shared/components/SearchBar/SearchBar';
-import type { Course } from '@/src/shared/utils';
+import type { DBCourse } from '@/src/shared/utils';
 import { alertError } from '@/src/shared/utils';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -80,7 +80,7 @@ const CoursesListPage: React.FC = () => {
                 </div>
               ) : (
                 <div className="grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                  {courses.map((course: Course) => (
+                  {courses.map((course: DBCourse) => (
                     <CourseCard key={course.id} course={course} />
                   ))}
                 </div>

--- a/client/src/pages/trainer/learning-paths/[id]/index.tsx
+++ b/client/src/pages/trainer/learning-paths/[id]/index.tsx
@@ -5,6 +5,8 @@ import Container from '@/src/shared/layouts/Container';
 import { Fragment } from 'react';
 import LearningPathLearnersSection from '@/src/sections/learning-paths/LearnersSection';
 import LearningPathContentSection from '@/src/sections/learning-paths/ContentSection';
+import SettingsSection from '@/src/sections/learning-paths/settingsSection';
+import EditSettingsButton from '@/src/sections/learning-paths/settingsSection/EditSettingsButton';
 
 interface LearningPath {
   id: number;
@@ -35,6 +37,7 @@ const LearningPathContent: React.FC = () => {
         <Container className="px-28">
           <div className="text-[20px] font-semibold my-5 text-textGray flex justify-between line-clamp-1">
             <h1>{learningPath?.name}</h1>
+            <EditSettingsButton />
           </div>
           <Tabs>
             <Tab title="Content">
@@ -44,7 +47,7 @@ const LearningPathContent: React.FC = () => {
               <LearningPathLearnersSection />
             </Tab>
             <Tab title="Settings">
-              <div>Learning Path Settings</div>
+              <SettingsSection />
             </Tab>
           </Tabs>
         </Container>

--- a/client/src/sections/courses/SettingsSection/index.tsx
+++ b/client/src/sections/courses/SettingsSection/index.tsx
@@ -7,7 +7,7 @@ import { changeEditMode, reset as courseReset } from '@/features/course/courseSl
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { courseSchema } from '@/src/shared/utils/validationSchemas';
-import DeleteModal from '@/src/shared/components/Modal/DeleteModal';
+import ConfirmationModal from '@/src/shared/components/Modal/ConfirmationModal';
 import { useConfirmBeforeLeave } from '@/src/shared/hooks/useConfirmBeforeLeave';
 import { useRouter } from 'next/router';
 
@@ -94,14 +94,14 @@ const SettingsSection: FC = () => {
           />
         </div>
       </div>
-      <DeleteModal
+      <ConfirmationModal
         state={isDeleteModalOpen}
         closeModal={() => {
           setIsDeleteModalOpen(false);
         }}
-        type="course"
-        title="Vue introduction"
-        onDelete={handleDelete}
+        item="course"
+        itemTitle="Vue introduction"
+        onConfirm={handleDelete}
       />
     </Fragment>
   );

--- a/client/src/sections/courses/create/AddLessonSection.tsx
+++ b/client/src/sections/courses/create/AddLessonSection.tsx
@@ -13,7 +13,7 @@ import {
   updateLesson,
 } from '@/features/course/courseSlice';
 import { v4 as uuidv4 } from 'uuid';
-import DeleteModal from '@/src/shared/components/Modal/DeleteModal';
+import ConfirmationModal from '@/src/shared/components/Modal/ConfirmationModal';
 import Lessons from './Lessons';
 
 const AddLessonSection: FC = () => {
@@ -71,12 +71,12 @@ const AddLessonSection: FC = () => {
         initialValues={edit}
         onSubmit={handleEditSubmit}
       />
-      <DeleteModal
+      <ConfirmationModal
         state={deleteL !== null}
         closeModal={() => dispatch(closeModal(lessonModalEnum.DELETE))}
-        type="lesson"
-        title={deleteL?.title ?? ''}
-        onDelete={handleDeleteLesson}
+        item="lesson"
+        itemTitle={deleteL?.title ?? ''}
+        onConfirm={handleDeleteLesson}
       />
     </div>
   );

--- a/client/src/sections/learning-paths/create/AddCourseSection.tsx
+++ b/client/src/sections/learning-paths/create/AddCourseSection.tsx
@@ -6,10 +6,11 @@ import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { closeModal, courseModalEnum, openModal } from '@/features/learning-path/courseModalsSlice';
 import CourseModal from './CourseModal';
 import { changeEditMode, deleteCourse } from '@/features/learning-path/learningPathSlice';
-import DeleteModal from '@/src/shared/components/Modal/DeleteModal';
+import ConfirmationModal from '@/src/shared/components/Modal/ConfirmationModal';
 
 const AddCourseSection = (): JSX.Element => {
   const { add, deleteC } = useAppSelector((state) => state.courseModals);
+  const { editMode } = useAppSelector((state) => state.learningPath);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -26,25 +27,27 @@ const AddCourseSection = (): JSX.Element => {
   return (
     <div>
       <Courses />
-      <Button
-        buttonClass="flex items-center space-x-1 border border-textGray !py-[5px] !px-2 text-[12px] !font-medium"
-        text="Add course"
-        onClick={() => dispatch(openModal({ type: courseModalEnum.ADD }))}
-      >
-        <PlusIcon />
-      </Button>
+      {editMode && (
+        <Button
+          buttonClass="flex items-center space-x-1 border border-textGray !py-[5px] !px-2 text-[12px] !font-medium"
+          text="Add course"
+          onClick={() => dispatch(openModal({ type: courseModalEnum.ADD }))}
+        >
+          <PlusIcon />
+        </Button>
+      )}
       <CourseModal
         title="Add Course"
         state={add}
         closeModal={() => dispatch(closeModal(courseModalEnum.ADD))}
         submitButtonTitle="Add course"
       />
-      <DeleteModal
+      <ConfirmationModal
         state={!!deleteC}
         closeModal={() => dispatch(closeModal(courseModalEnum.DELETE))}
-        type="course"
-        title={deleteC?.name ?? ''}
-        onDelete={handleDeleteCourse}
+        item="course"
+        itemTitle={deleteC?.name ?? ''}
+        onConfirm={handleDeleteCourse}
       />
     </div>
   );

--- a/client/src/sections/learning-paths/create/CourseItem.tsx
+++ b/client/src/sections/learning-paths/create/CourseItem.tsx
@@ -1,4 +1,4 @@
-import { useAppDispatch } from '@/app/hooks';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { courseModalEnum, openModal } from '@/features/learning-path/courseModalsSlice';
 import Collapse from '@/src/shared/components/Collapse/Collapse';
 import FourDotsIcon from '@/src/shared/icons/FourDotsIcon';
@@ -9,13 +9,18 @@ interface CourseItemProps {
 }
 
 const CourseItem = ({ course }: CourseItemProps): JSX.Element => {
+  const { editMode } = useAppSelector((state) => state.learningPath);
   const dispatch = useAppDispatch();
   return (
     <Collapse
       label={course.name}
-      onDelete={() => {
-        dispatch(openModal({ type: courseModalEnum.DELETE, course }));
-      }}
+      onDelete={
+        editMode
+          ? () => {
+              dispatch(openModal({ type: courseModalEnum.DELETE, course }));
+            }
+          : undefined
+      }
     >
       {/* Change to `course.lessons` during integration */}
       {lessons.length > 0 &&

--- a/client/src/sections/learning-paths/create/InitialSection.tsx
+++ b/client/src/sections/learning-paths/create/InitialSection.tsx
@@ -26,9 +26,15 @@ interface InitialSectionProps {
   register?: UseFormRegister<any>;
   errors?: FieldErrors<FieldValues>;
   control?: any;
+  showStatus?: boolean;
 }
 
-const InitialSection = ({ register, errors, control }: InitialSectionProps): JSX.Element => {
+const InitialSection = ({
+  register,
+  errors,
+  control,
+  showStatus = true,
+}: InitialSectionProps): JSX.Element => {
   const { values: learningPath, editMode } = useAppSelector((state) => state.learningPath);
   const dispatch = useAppDispatch();
   const categoriesOption: MultiSelectOptionData[] = categories.map(({ id, name }) => ({
@@ -163,26 +169,28 @@ const InitialSection = ({ register, errors, control }: InitialSectionProps): JSX
           </div>
         )}
       </div>
-      <div className="my-4">
-        <h3 className="text-gray-700 text-sm font-medium mb-2">Status</h3>
-        <div className="w-[111px]">
-          <Dropdown
-            disabled={!editMode}
-            buttonText={learningPath.isActive ? 'Active' : 'Inactive'}
-            buttonIcon={<ChevronDown height={16} width={16} color="#172826" />}
-            options={[
-              { label: 'Active', value: 'Active' },
-              {
-                label: 'Inactive',
-                value: 'Inactive',
-              },
-            ]}
-            onChange={(val) => {
-              dispatch(updateForm({ isActive: val === 'Active' }));
-            }}
-          />
+      {showStatus && (
+        <div className="my-4">
+          <h3 className="text-gray-700 text-sm font-medium mb-2">Status</h3>
+          <div className="w-[111px]">
+            <Dropdown
+              disabled={!editMode}
+              buttonText={learningPath.isActive ? 'Active' : 'Inactive'}
+              buttonIcon={<ChevronDown height={16} width={16} color="#172826" />}
+              options={[
+                { label: 'Active', value: 'Active' },
+                {
+                  label: 'Inactive',
+                  value: 'Inactive',
+                },
+              ]}
+              onChange={(val) => {
+                dispatch(updateForm({ isActive: val === 'Active' }));
+              }}
+            />
+          </div>
         </div>
-      </div>
+      )}
     </Fragment>
   );
 };

--- a/client/src/sections/learning-paths/settingsSection/EditSettingsButton.tsx
+++ b/client/src/sections/learning-paths/settingsSection/EditSettingsButton.tsx
@@ -1,22 +1,15 @@
-/* eslint-disable multiline-ternary */
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { changeEditMode, reset as courseReset } from '@/features/course/courseSlice';
+import { changeEditMode } from '@/features/learning-path/learningPathSlice';
 import { setIsTabValid } from '@/features/tab/tabSlice';
-import { useGetCourseQuery } from '@/services/courseAPI';
 import EditModeButtons from '@/src/shared/components/Button/EditModeButtons';
-import { courseSchema } from '@/src/shared/utils/validationSchemas';
+import { learningPathSchema } from '@/src/shared/utils/validationSchemas';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useRouter } from 'next/router';
-import { type FC, Fragment, useEffect } from 'react';
+import { useEffect, type FC, Fragment } from 'react';
 import { useForm } from 'react-hook-form';
 
 const EditSettingsButton: FC = () => {
-  const { query } = useRouter();
   const { activeTab } = useAppSelector((state) => state.tab);
-  const { editMode, values } = useAppSelector((state) => state.course);
-  const { data: course } = useGetCourseQuery(query.id, {
-    skip: query.id === undefined,
-  });
+  const { editMode, values } = useAppSelector((state) => state.learningPath);
 
   const dispatch = useAppDispatch();
   const defaultValues = {
@@ -28,13 +21,13 @@ const EditSettingsButton: FC = () => {
   };
 
   const { trigger, reset } = useForm({
-    resolver: yupResolver(courseSchema),
+    resolver: yupResolver(learningPathSchema),
     mode: 'onChange',
     defaultValues,
   });
 
   const handleCancel = (): void => {
-    dispatch(courseReset(course));
+    // Please reset the learing path with previously fetched data from BE in the integration
     dispatch(setIsTabValid(true));
     dispatch(changeEditMode(false));
   };
@@ -42,17 +35,17 @@ const EditSettingsButton: FC = () => {
   const onSave = async (): Promise<void> => {
     let areInputsValid = true;
     if (values.image) {
-      areInputsValid = await trigger(['image', 'name', 'category']);
+      areInputsValid = await trigger(['image', 'description', 'name', 'category']);
     } else {
-      areInputsValid = await trigger(['name', 'category']);
+      areInputsValid = await trigger(['name', 'description', 'category']);
     }
 
-    const isValidated = areInputsValid && values.lessons.length > 0;
+    const isValidated = areInputsValid && values.courses.length > 0;
     dispatch(setIsTabValid(isValidated));
 
     if (isValidated) {
       dispatch(changeEditMode(false));
-      // Please place the logic for saving the course edit form here
+      // Please place the logic for saving the learning path edit form here
       alert('The information provided has been saved');
     }
   };

--- a/client/src/sections/learning-paths/settingsSection/index.tsx
+++ b/client/src/sections/learning-paths/settingsSection/index.tsx
@@ -1,0 +1,123 @@
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import {
+  changeEditMode,
+  reset as learningPathReset,
+} from '@/features/learning-path/learningPathSlice';
+import { type FC, Fragment, useEffect, useState } from 'react';
+import InitialSection from '../create/InitialSection';
+import Button from '@/src/shared/components/Button';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { learningPathSchema } from '@/src/shared/utils/validationSchemas';
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/router';
+import { useConfirmBeforeLeave } from '@/src/shared/hooks/useConfirmBeforeLeave';
+import AddCourseSection from '../create/AddCourseSection';
+import ConfirmationModal from '@/src/shared/components/Modal/ConfirmationModal';
+
+const SettingsSection: FC = () => {
+  const { values, editMode } = useAppSelector((state) => state.learningPath);
+  const { isTabValid } = useAppSelector((state) => state.tab);
+  const [isArchiveModalOpen, setIsArchiveModalOpen] = useState(false);
+  const { asPath, events } = useRouter();
+
+  // Please remove this isActive and replace it with the incoming learning path status in learningPathStatus variable
+  const isActive = true;
+  const learningPathStatus = isActive ? 'Archive' : 'Activate';
+
+  const dispatch = useAppDispatch();
+  useConfirmBeforeLeave(editMode);
+
+  const defaultValues = {
+    ...values,
+    category: values.category.map(({ name, id }) => ({
+      label: name,
+      value: id,
+    })),
+  };
+
+  const {
+    register,
+    trigger,
+    reset,
+    control,
+    formState: { errors },
+  } = useForm({
+    resolver: yupResolver(learningPathSchema),
+    mode: 'onChange',
+    defaultValues,
+  });
+
+  const handleArchive = (): void => {
+    // Archive or activate learing path logic goes here
+    alert('Archive action has been confirmed');
+  };
+
+  useEffect(() => {
+    if (!isTabValid) {
+      if (values.image) {
+        void trigger(['image', 'description', 'name', 'category']);
+      } else {
+        void trigger(['name', 'description', 'category']);
+      }
+    }
+  }, [isTabValid]);
+
+  useEffect(() => {
+    dispatch(changeEditMode(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    reset(defaultValues);
+  }, [editMode]);
+
+  useEffect(() => {
+    const prevPath = asPath;
+    events?.on('routeChangeComplete', (newPath) => {
+      if (newPath !== prevPath) {
+        dispatch(learningPathReset());
+      }
+    });
+  }, []);
+  return (
+    <Fragment>
+      <InitialSection register={register} errors={errors} control={control} showStatus={false} />
+      <h3 className="font-medium text-[14px] mb-2 mt-4 text-textGray">List of courses</h3>
+      <AddCourseSection />
+
+      <div className="mt-4 mb-[146px] space-y-2 w-[70%]">
+        <h3 className="text-danger text-[14px] font-medium">Danger Zone</h3>
+        <div className="flex justify-between items-center border border-danger p-4 rounded-md text-[12px]">
+          <div className="text-textGray">
+            <h3 className="font-medium">{learningPathStatus} learning path</h3>
+            <p className="font-normal">
+              {learningPathStatus} learning path and set status to{' '}
+              {isActive ? 'inactive' : 'active'}.
+            </p>
+          </div>
+          <Button
+            onClick={() => {
+              setIsArchiveModalOpen(true);
+            }}
+            text={learningPathStatus}
+            buttonClass="border border-danger text-danger py-1 px-[18px] rounded-md"
+          />
+        </div>
+      </div>
+      <ConfirmationModal
+        state={isArchiveModalOpen}
+        closeModal={() => {
+          setIsArchiveModalOpen(false);
+        }}
+        action={learningPathStatus.toLowerCase()}
+        item="learning path"
+        // Please change this name on integration to the lerning path name
+        itemTitle="Learning path"
+        onConfirm={handleArchive}
+        confirmTitle="Confirm"
+      />
+    </Fragment>
+  );
+};
+
+export default SettingsSection;

--- a/client/src/shared/components/Button/EditModeButtons.tsx
+++ b/client/src/shared/components/Button/EditModeButtons.tsx
@@ -1,0 +1,38 @@
+import { type FC, Fragment } from 'react';
+import Button from '.';
+
+interface EditModeButtonsProps {
+  editMode: boolean;
+  onCancel: () => void;
+  onSave: () => void;
+  onEdit: () => void;
+}
+
+const EditModeButtons: FC<EditModeButtonsProps> = ({ editMode, onCancel, onSave, onEdit }) => {
+  return (
+    <Fragment>
+      {editMode ? (
+        <div className="flex space-x-1">
+          <Button
+            onClick={onCancel}
+            text="Cancel"
+            buttonClass="border border-textGray !font-medium text-[14px] py-[6px] !px-4 "
+          />
+          <Button
+            onClick={onSave}
+            text="Save changes"
+            buttonClass="border border-red text-red !font-medium text-[14px] px-[18px] py-[6.5px] font-inter"
+          />
+        </div>
+      ) : (
+        <Button
+          onClick={onEdit}
+          text="Edit settings"
+          buttonClass="border border-red text-red !font-medium text-[14px] px-[18px] py-[6.5px] font-inter"
+        />
+      )}
+    </Fragment>
+  );
+};
+
+export default EditModeButtons;

--- a/client/src/shared/components/Card/CourseCard/index.tsx
+++ b/client/src/shared/components/Card/CourseCard/index.tsx
@@ -1,17 +1,11 @@
-import type { Course } from '@/src/shared/utils';
+import type { DBCourse } from '@/src/shared/utils';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
 
 interface Props {
-  course: Course;
+  course: DBCourse;
 }
-
-const generateStarRating = (rating: number): string => {
-  const starCount = 5;
-  const roundedRating = Math.round(rating);
-  return `${'★'.repeat(roundedRating)}${'☆'.repeat(starCount - roundedRating)}`;
-};
 
 const CourseCard: React.FC<Props> = ({ course }: Props) => {
   return (
@@ -28,19 +22,13 @@ const CourseCard: React.FC<Props> = ({ course }: Props) => {
         </div>
         <div className="p-3">
           <div className="text-lg font-semibold">{course.name}</div>
-          <div className="text-xs text-gray-400">
+          <div className="text-xs text-gray-400 mb-3">
             {course.description ?? 'No description to show'}
-          </div>
-          <div className="flex items-center gap-1 mb-3">
-            <span className="text-lightBrown text-sm font-semibold">{course.ratings}</span>
-            <span className="flex text-[#ffd700] text-lg">
-              {generateStarRating(course.ratings)}
-            </span>
           </div>
 
           <div className="text-sm font-semibold mb-1">Categories:</div>
           <div className="relative flex justify-between">
-            {course.categories?.map((category, index) => (
+            {course.category.map((category, index) => (
               <span
                 className="text-xs font-semibold text-gray-400 border-2 border-gray-400 px-2 py-1 my-1 rounded-full transition-color duration-300 hover:bg-gray-50"
                 key={index}

--- a/client/src/shared/components/Collapse/Collapse.tsx
+++ b/client/src/shared/components/Collapse/Collapse.tsx
@@ -20,18 +20,20 @@ const Collapse: React.FC<collapseProps> = ({ label, children, onDelete }) => {
   const arrowClasses = isOpen ? 'rotate-180 order-last' : 'order-last';
 
   return (
-    <div className="flex flex-col divide-y border border-neutral-200 rounded-[5px]">
+    <div className="flex flex-col divide-y border border-neutral-200 rounded-[5px] cursor-pointer">
       <div className="flex p-4 items-center" onClick={toggleCollapse}>
         <div className="flex gap-1 items-center w-full mr-4">
           <FourDotsIcon />
           <span className="text-sm flex-1">{label}</span>
-          {!!onDelete && <TrashIcon
-            className="opacity-50 cursor-pointer"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-          />}
+          {!!onDelete && (
+            <TrashIcon
+              className="opacity-50 cursor-pointer"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+            />
+          )}
         </div>
         <ChevronDown height={16} width={16} className={`${arrowClasses} `} />
       </div>

--- a/client/src/shared/components/Modal/ConfirmationModal.tsx
+++ b/client/src/shared/components/Modal/ConfirmationModal.tsx
@@ -3,25 +3,31 @@ import Modal from '@/src/shared/components/Modal/Modal';
 import XmarkIcon from '../../icons/XmarkIcon';
 import Button from '../Button';
 
-interface DeleteModalProps {
+interface ConfirmationModalProps {
   state: boolean;
-  type: string;
-  title: string;
+  item: string;
+  action?: string;
+  itemTitle: string;
+  confirmTitle?: string;
   closeModal: () => void;
-  onDelete: () => void;
+  onConfirm: () => void;
 }
 
-const DeleteModal: FC<DeleteModalProps> = ({
+const ConfirmationModal: FC<ConfirmationModalProps> = ({
   state,
-  type = '',
-  title = '',
+  item = '',
+  itemTitle = '',
+  action = 'delete',
+  confirmTitle = 'Delete',
   closeModal,
-  onDelete,
+  onConfirm,
 }) => {
   return (
     <Modal className="p-4 !w-[30%]" isOpen={state}>
       <div className="flex items-center justify-between pb-4 mb-4">
-        <h2 className="text-[16px] font-medium">Delete confirmation</h2>
+        <h2 className="text-[16px] font-medium">
+          <span className="capitalize">{action}</span> confirmation
+        </h2>
         <XmarkIcon
           className="cursor-pointer"
           onClick={() => {
@@ -30,8 +36,8 @@ const DeleteModal: FC<DeleteModalProps> = ({
         />
       </div>
       <p className="font-normal">
-        You are about to delete a {type}. Are you sure you want to delete{' '}
-        <span className="text-red">{title}</span>?
+        You are about to {action} a {item}. Are you sure you want to {action}{' '}
+        <span className="text-red">{itemTitle}</span>?
       </p>
       <div className="flex mt-[48px] justify-center space-x-2 text-[14px]">
         <Button
@@ -43,15 +49,15 @@ const DeleteModal: FC<DeleteModalProps> = ({
         />
         <Button
           onClick={() => {
-            onDelete();
+            onConfirm();
           }}
           type="submit"
           buttonClass="border border-red !text-red py-[6px] !w-36 !font-medium"
-          text="Delete"
+          text={confirmTitle}
         />
       </div>
     </Modal>
   );
 };
 
-export default DeleteModal;
+export default ConfirmationModal;

--- a/client/src/shared/components/Modal/Modal.tsx
+++ b/client/src/shared/components/Modal/Modal.tsx
@@ -1,7 +1,15 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect } from 'react';
 import { type ModalProps } from '../../utils';
 
 const Modal: React.FC<ModalProps> = ({ children, isOpen, className = '' }: ModalProps) => {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return (

--- a/client/src/shared/components/Tabs/index.tsx
+++ b/client/src/shared/components/Tabs/index.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/consistent-indexed-object-style */
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { setActiveTab } from '@/features/tab/tabSlice';
+import { reset, setActiveTab } from '@/features/tab/tabSlice';
 import { Children, Fragment, useEffect, useState, type FC, type ReactElement } from 'react';
 import { type ChildElementObject } from '../../utils/interface';
 import { type TabProps } from './Tab';
+import { useRouter } from 'next/router';
 
 interface TabsProps {
   children: ReactElement<TabProps> | Array<ReactElement<TabProps>>;
@@ -13,6 +14,7 @@ const Tabs: FC<TabsProps> = ({ children }) => {
   const { activeTab } = useAppSelector((state) => state.tab);
   const dispatch = useAppDispatch();
   const [childrenList, setChildrenList] = useState<ChildElementObject>({});
+  const { events } = useRouter();
 
   useEffect(() => {
     let tab = 0;
@@ -35,6 +37,11 @@ const Tabs: FC<TabsProps> = ({ children }) => {
     setChildrenList(childrenListObj);
   }, [children, activeTab]);
 
+  useEffect(() => {
+    events.on('routeChangeComplete', () => {
+      dispatch(reset());
+    });
+  }, []);
   return (
     <Fragment>
       <div className="hidden md:flex mb-4 border-b">


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/LMS-632

## Definition of Done
- have edit setting button that allows trainer to edit context of learning path
- have inputs for name and description
- display list of courses  
- display toggle icon and expand course on click
- display archive button
- display add course button
- toggle edit mode
- have a modal for adding new course in a learning path based on the figma design
The modal should display:
    - Filter button
     - Search bar
     - List of courses (static)
     - Pagination
      - Cancel and add course buttons


## Affected Components / Functionalities / Page
 - client/features/learning-path/learningPathSlice.ts
 - client/features/tab/tabSlice.ts
 - client/src/pages/trainer/courses/index.tsx
 - client/src/pages/trainer/learning-paths/[id]/index.tsx
 - client/src/sections/courses/SettingsSection/EditSettingsButton.tsx
 - client/src/sections/courses/SettingsSection/index.tsx
 - client/src/sections/courses/create/AddLessonSection.tsx
 - client/src/sections/learning-paths/create/AddCourseSection.tsx
 - client/src/sections/learning-paths/create/CourseItem.tsx
 - client/src/sections/learning-paths/create/InitialSection.tsx
 - client/src/shared/components/Card/CourseCard/index.tsx
 - client/src/shared/components/Collapse/Collapse.tsx
 - client/src/shared/components/Tabs/index.tsx

## Screenshots
![image](https://github.com/framgia/sph-lms/assets/110364690/36ad2c11-68cb-467b-a724-ddc1a3591e13)