### PR TITLE
LMS-610 [API/ Integration] [Learners tab] Sorting learners

### DIFF
--- a/api/app_sph_lms/api/serializer/course_serializer.py
+++ b/api/app_sph_lms/api/serializer/course_serializer.py
@@ -94,9 +94,19 @@ class CourseTraineeSerializer(serializers.ModelSerializer):
                     'is_enrolled',
                     "true"
                 )
+        sortingOption = self.context[
+                'request'
+            ].query_params.get(
+                    'selectedSortOption',
+                    "A - Z",
+                )
 
         if is_enrolled == "true":
-            course_trainees = CourseTrainee.objects.filter(course=obj)
+            if sortingOption == "A - Z":
+                course_trainees = CourseTrainee.objects.order_by('trainee__trainee__first_name').filter(course=obj)
+            if sortingOption == "Z - A":
+                course_trainees = CourseTrainee.objects.order_by('-trainee__trainee__first_name').filter(course=obj)
+
             data = [
                 {
                     "trainee_id": trainee.id,

--- a/client/features/course/learnerSlice.ts
+++ b/client/features/course/learnerSlice.ts
@@ -13,11 +13,13 @@ export interface Trainee {
 interface TraineeData {
   trainees: Trainee[];
   page: number;
+  selectedSortOption: string;
 }
 
 const initialState: TraineeData = {
   trainees: [],
   page: 1,
+  selectedSortOption: 'A - Z',
 };
 
 const learnerSlice = createSlice({
@@ -34,13 +36,17 @@ const learnerSlice = createSlice({
       });
       state.trainees.push(...newTrainees);
     },
-
     seeMoreTrainees: (state) => {
       state.page += 1;
+    },
+    resetTraineesList: (state: TraineeData, action: PayloadAction<string>) => {
+      state.trainees = [];
+      state.page = 1;
+      state.selectedSortOption = action.payload;
     },
   },
 });
 
-export const { addTrainees, seeMoreTrainees } = learnerSlice.actions;
+export const { addTrainees, seeMoreTrainees, resetTraineesList } = learnerSlice.actions;
 
 export default learnerSlice.reducer;

--- a/client/services/traineeAPI.ts
+++ b/client/services/traineeAPI.ts
@@ -13,12 +13,13 @@ export const getCourseTrainee = createApi({
   tagTypes: ['CourseTrainee'],
   endpoints: (builder) => ({
     getLearner: builder.query({
-      query: ({ courseId, isEnrolled, searchQuery, pageNumber }) => ({
+      query: ({ courseId, isEnrolled, searchQuery, pageNumber, selectedSortOption }) => ({
         url: `course/${courseId}/trainee`,
         params: {
           is_enrolled: isEnrolled,
           search: searchQuery,
           page: pageNumber,
+          selectedSortOption: selectedSortOption,
         },
       }),
       providesTags: ['CourseTrainee'],

--- a/client/src/shared/components/Dropdown/index.tsx
+++ b/client/src/shared/components/Dropdown/index.tsx
@@ -40,7 +40,7 @@ const Dropdown: React.FC<DropdownProps> = ({
       <button
         type="button"
         disabled={disabled}
-        className="flex items-center justify-between w-full p-2 text-sm"
+        className="flex items-center justify-between w-[219px] py-[3px] p-2 text-sm"
         onClick={() => {
           setIsOpen(!isOpen);
         }}
@@ -55,7 +55,7 @@ const Dropdown: React.FC<DropdownProps> = ({
             {options.map((option, index) => (
               <button
                 key={option.value}
-                className={`flex items-center w-[177px] h-[37px] text-sm text-left pl-2 text-gray-700 bg-white hover:bg-gray-100 hover:text-gray-900 border border-b-gray-200 ${
+                className={`flex text-left items-center w-[177px] h-[37px] text-sm pl-2 text-gray-700 bg-white hover:bg-gray-100 hover:text-gray-900 border border-b-gray-200 ${
                   index === 0 ? 'rounded-tl-lg rounded-tr-lg' : ''
                 } ${index === optionsCount ? 'rounded-bl-lg rounded-br-lg' : ''}`}
                 onClick={() => {


### PR DESCRIPTION
## Issue Link
[LMS-610 [API/ Integration] [Learners tab] Sorting learners](https://framgiaph.backlog.com/view/LMS-610)


## Definition of Done
Create an api for filtering learners that is associated with the course in course detail page
- Can be sorted in Alphabetically (asc or desc)
- Removed sorting on progress sicne it is moved to next phase

## Steps to reproduce
1. go to `http://localhost:3000/trainer/courses`
2. select any courses
3. if there is no learners, add learners
4. sort learners

## Affected Components / Functionalities / Page
`http://[localhost:3000/trainer/courses/1](http://localhost:3000/trainer/courses/COURSE_ID)`

## Test Cases

- [x] ensure that the API is able to sort the learner data alphabetically based on the provided parameters.
- [x] learner list is updated dynamically based on the selected sorting option.

## Notes
n/a

## Screenshots
![image](https://github.com/framgia/sph-lms/assets/81206481/5927a80b-a457-44d2-b2c0-2b4990b14204)

![image](https://github.com/framgia/sph-lms/assets/81206481/eb45ec28-5e9c-4d0b-a34d-8f9560bfd48e)
