### PR TITLE
[LMS-645] [BUGFIX] CourseCard Components & Lesson Item Component Fixes

### DIFF
--- a/client/src/sections/courses/create/LessonItem.tsx
+++ b/client/src/sections/courses/create/LessonItem.tsx
@@ -16,7 +16,7 @@ const LessonItem: FC<LessonItemProps> = ({ lesson }) => {
 
   return (
     <div className="flex items-center min-w-[70%] w-fit p-[17px] border rounded-md space-x-1 bg-white">
-      <FourDotsIcon />
+      {editMode && <FourDotsIcon />}
       <h3 className="flex-grow text-[14px]">{lesson.title}</h3>
       {editMode && (
         <div className="flex space-x-[10px]">

--- a/client/src/sections/learning-paths/ContentSection/index.tsx
+++ b/client/src/sections/learning-paths/ContentSection/index.tsx
@@ -31,7 +31,7 @@ export default LearningPathContentSection;
 const courses: Course[] = [
   {
     id: 1,
-    name: 'HTML Crash Course',
+    name: 'The Everlasting Pursuit: Unveiling the Mysteries of Human Existence',
     image: '/image1.jpg',
     lessons: [
       {

--- a/client/src/sections/learning-paths/create/CourseItem.tsx
+++ b/client/src/sections/learning-paths/create/CourseItem.tsx
@@ -9,14 +9,15 @@ interface CourseItemProps {
 }
 
 const CourseItem = ({ course }: CourseItemProps): JSX.Element => {
-  const { editMode } = useAppSelector((state) => state.learningPath);
+  const { editMode: courseEditMode } = useAppSelector((state) => state.course);
+  const { editMode: learningPathEditMode } = useAppSelector((state) => state.learningPath);
   const dispatch = useAppDispatch();
   const { name, lessons } = course;
   return (
     <Collapse
       label={name}
       onDelete={
-        editMode
+        learningPathEditMode
           ? () => {
               dispatch(openModal({ type: courseModalEnum.DELETE, course }));
             }
@@ -27,7 +28,7 @@ const CourseItem = ({ course }: CourseItemProps): JSX.Element => {
         lessons.map((lesson) => {
           return (
             <div key={lesson.id} className="flex gap-1 items-center w-full py-4 px-6">
-              <FourDotsIcon />
+              {courseEditMode && <FourDotsIcon />}
               <h3 className="text-xs">{lesson.title}</h3>
             </div>
           );

--- a/client/src/shared/components/Card/CourseCard/index.tsx
+++ b/client/src/shared/components/Card/CourseCard/index.tsx
@@ -21,15 +21,15 @@ const CourseCard: React.FC<Props> = ({ course }: Props) => {
           />
         </div>
         <div className="p-3">
-          <div className="text-lg font-semibold">{course.name}</div>
-          <div className="text-xs text-gray-400 mb-3">
+          <div className="text-dark font-medium truncate" title={course.name}>{course.name}</div>
+          <div className="text-xs h-12 text-gray-400 mb-3 line-clamp-3">
             {course.description ?? 'No description to show'}
           </div>
-          <div className="text-sm font-semibold mb-1">Categories:</div>
-          <div className="relative flex justify-between">
+          <div className="text-xs text-dark  font-semibold mb-1">Categories:</div>
+          <div className="flex flex-wrap gap-1">
             {course?.category?.map((category, index) => (
               <span
-                className="text-xs font-semibold text-gray-400 border-2 border-gray-400 px-2 py-1 my-1 rounded-full transition-color duration-300 hover:bg-gray-50"
+                className="text-xs font-semibold text-gray-400 border border-gray-400 px-2 py-1 rounded-full transition-color duration-300 hover:bg-gray-50"
                 key={index}
               >
                 {category.name}

--- a/client/src/shared/components/Card/LearningPathCard/index.tsx
+++ b/client/src/shared/components/Card/LearningPathCard/index.tsx
@@ -24,17 +24,17 @@ const LearningPathCard: React.FC<Props> = ({ learningPath }: Props) => {
         </div>
         <div className="flex flex-col gap-[21px] p-4">
           <div>
-            <div className="text-lg font-semibold">{name}</div>
+            <div className="font-medium text-dark truncate" title={learningPath.name}>{learningPath.name}</div>
             <div className="text-xs text-gray-400">{`${courseCount} ${
-              courseCount === 1 ? 'course' : 'courses'
+              courseCount > 1 ? 'courses' : 'course'
             }`}</div>
           </div>
           <div className="flex flex-col gap-1">
             <div className="text-sm font-normal">Categories:</div>
-            <div className="flex flex-start gap-1">
+            <div className="flex flex-wrap gap-1">
               {category?.map((category) => (
                 <span
-                  className="text-xs font-normal text-disabled border border-disabled px-2 py-1 rounded-full transition-color duration-300 hover:bg-gray-50"
+                  className="text-xs font-semibold text-gray-400 border border-gray-400 px-2 py-1 rounded-full transition-color duration-300 hover:bg-gray-50"
                   key={category.id}
                 >
                   {category.name}

--- a/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
+++ b/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
@@ -10,7 +10,7 @@ const LearningPathCourseCard = ({ course }: Props): JSX.Element => {
   const lessonCount = course.lessons?.length ?? 0;
   return (
     <Link href={`/trainer/courses/${course.id}`}>
-      <div className="flex w-fit min-w-[420px] min-h-[128px] overflow-hidden bg-white border rounded-[5px] border-neutral-100">
+      <div className="flex w-[420px] min-h-[128px] overflow-hidden bg-white border rounded-[5px] border-neutral-100">
         <Image
           src={course.image ?? '/image1.jpg'}
           width={150}
@@ -19,7 +19,7 @@ const LearningPathCourseCard = ({ course }: Props): JSX.Element => {
           className="object-cover"
         />
         <div className="w-full p-4 flex flex-col gap-2">
-          <h3>{course.name}</h3>
+          <h3 className="line-clamp-2" title={course.name}>{course.name}</h3>
           <div className="flex flex-col text-xs">
             <span className="text-disabled">
               {lessonCount} {lessonCount === 1 ? 'lesson' : 'lessons'} available


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/LMS-645

## Defintion of Done
- [x] Catergories should not overflow across the various screen size of the box
- [x] Rearrange icon should not be display if edit is not active
- [x] Truncated title remains readable and does not lose its meaning or become unclear

## Steps to reproduce
Go to `http://localhost:3000/trainer/courses`
Go to course detail settings

## Affected Components / Functionalities / Page
- Courses page
- Learning Paths page
- Lesson Item
- Course Card
- Learning Path Card

## Test Cases
_will update soon..._

## Notes
n/a

## Screenshots
Course Card
![image](https://github.com/framgia/sph-lms/assets/111732984/f672597a-9b30-48c1-905b-fa8315bc7e6d)

Learning Path Card
![image](https://github.com/framgia/sph-lms/assets/111732984/3a24c12f-d247-4a1a-985e-1b14800059e1)

View mode
![image](https://github.com/framgia/sph-lms/assets/111732984/e5040c7d-bceb-4417-8cc3-92818f8f8e8d)

Edit mode
![image](https://github.com/framgia/sph-lms/assets/111732984/86564fcd-6410-4b16-bfb9-dd0faad1b5f7)


