### PR TITLE
[LMS-624] [API/Integration] Trainer can search learning path

### DIFF
--- a/api/app_sph_lms/api/serializer/learning_path_serializer.py
+++ b/api/app_sph_lms/api/serializer/learning_path_serializer.py
@@ -30,10 +30,10 @@ class LearningPathSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = LearningPath
-        exclude = ['author']
+        exclude = ['author', 'trainee']
 
     def get_course_count(self, instance):
-      return instance.courses.all().count()
+        return instance.courses.all().count()
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)

--- a/client/services/learningPathAPI.ts
+++ b/client/services/learningPathAPI.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/indent */
 import { getUserToken } from '@/src/shared/utils';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
@@ -10,14 +11,20 @@ export const getLearningPath = createApi({
       return headers;
     },
   }),
+  tagTypes: ['LearningPath'],
   endpoints: (builder) => ({
-    getLearningPaths: builder.query<any, { page: number; pageSize?: number; isActive?: boolean }>({
-      query: ({ page, pageSize, isActive }) => {
+    getLearningPaths: builder.query<
+      any,
+      { page: number; pageSize?: number; isActive?: boolean; search?: string }
+    >({
+      query: ({ page, pageSize, isActive, search }) => {
         const pageParam = `page=${page}`;
         const pageSizeParam = pageSize ? `&page_size=${pageSize}` : '';
         const statusParam = isActive !== undefined ? `&is_active=${isActive}` : '';
-        return `learning-path?${pageParam}${pageSizeParam}${statusParam}`;
+        const searchParam = search ? `&search=${search}` : '';
+        return `learning-path?${pageParam}${pageSizeParam}${statusParam}${searchParam}`;
       },
+      providesTags: ['LearningPath'],
     }),
     createLearningPath: builder.mutation({
       query: (data) => ({
@@ -25,6 +32,7 @@ export const getLearningPath = createApi({
         method: 'POST',
         body: data,
       }),
+      invalidatesTags: ['LearningPath'],
     }),
   }),
 });

--- a/client/src/pages/trainer/learning-paths/index.tsx
+++ b/client/src/pages/trainer/learning-paths/index.tsx
@@ -6,11 +6,14 @@ import Link from 'next/link';
 import { Fragment, useState } from 'react';
 
 const LearningPathListPage: React.FC = () => {
+  const [search, setSearch] = useState('');
   const [activePage, setActivePage] = useState(1);
   const [inactivePage, setInactivePage] = useState(1);
 
-  const handleSearch = (value: string): void => {
-    console.log(value);
+  const handleSearch = (search: string): void => {
+    setSearch(search);
+    setActivePage(1);
+    setInactivePage(1);
   };
 
   const renderTabContent = (status: boolean): JSX.Element => {
@@ -18,6 +21,7 @@ const LearningPathListPage: React.FC = () => {
       <LearningPathList
         isActive={status}
         page={status ? activePage : inactivePage}
+        search={search}
         handleChangePageEvent={(page) => {
           status ? setActivePage(page) : setInactivePage(page);
         }}

--- a/client/src/sections/learning-paths/index.tsx
+++ b/client/src/sections/learning-paths/index.tsx
@@ -8,16 +8,19 @@ interface LearningPathListProps {
   isActive: boolean;
   page: number;
   handleChangePageEvent: (page: number) => void;
+  search?: string;
 }
 
 const LearningPathList = ({
   isActive,
   page,
   handleChangePageEvent,
+  search = '',
 }: LearningPathListProps): JSX.Element => {
   const { data, error, isLoading } = useGetLearningPathsQuery({
     page,
     isActive,
+    search,
   });
 
   if (isLoading) {


### PR DESCRIPTION
## Issue Link
[LMS-624 [API/Integration] Trainer can search learning path](https://framgiaph.backlog.com/view/LMS-624)

## Defintion of Done

- [x] Can search for Learning Path using the search bar on the LP list page 

## Steps to reproduce
1. Login as trainer
2. Go to `http://localhost:3000/trainer/learning-paths`
3. Input in the search bar and hit enter

## Affected Components / Functionalities / Page
BE
- Learning path serializer

FE
- Learning Paths Page

## Test Cases
_will update soon..._

## Notes
- Included fix for Add Learning Path bug
- Updated `client/services/learningPathAPI` to include `Tags` for fetching of newly created LPs

## Screenshots
[Screencast 2023-06-09 11-20-44.webm](https://github.com/framgia/sph-lms/assets/116238730/e06421c5-b15f-43d4-bf6a-5adaea997f25)
