### PR TITLE
[LMS-646] Learners Tab (Course & Learning Path) adjustments

### DIFF
--- a/client/features/learning-path/learnerSlice.ts
+++ b/client/features/learning-path/learnerSlice.ts
@@ -12,11 +12,13 @@ export interface Trainee {
 interface TraineeData {
   trainees: Trainee[];
   page: number;
+  selectedSortOption: string;
 }
 
 const initialState: TraineeData = {
   trainees: [],
   page: 1,
+  selectedSortOption: 'A - Z',
 };
 
 const learnerSlice = createSlice({
@@ -33,9 +35,14 @@ const learnerSlice = createSlice({
     seeMoreTrainees: (state) => {
       state.page += 1;
     },
+    resetTraineesList: (state: TraineeData, action: PayloadAction<string>) => {
+      state.trainees = [];
+      state.page = 1;
+      state.selectedSortOption = action.payload;
+    },
   },
 });
 
-export const { addTrainees, seeMoreTrainees } = learnerSlice.actions;
+export const { addTrainees, seeMoreTrainees, resetTraineesList } = learnerSlice.actions;
 
 export default learnerSlice.reducer;

--- a/client/src/sections/courses/LearningSection/index.tsx
+++ b/client/src/sections/courses/LearningSection/index.tsx
@@ -13,8 +13,10 @@ import {
   resetTraineesList,
 } from '@/features/course/learnerSlice';
 import Button from '@/src/shared/components/Button';
-import Dropdown, { type SortOption } from '@/src/shared/components/Dropdown';
 import AddLearnerModal from './AddLearnerModal';
+import SortDropdown, {
+  type SortOption,
+} from '@/src/shared/components/Dropdown/SortDropdown/SortDropdown';
 
 const LearningSection: React.FC = () => {
   const [selectedSortOption, setSelectedSortOption] = useState('A - Z');
@@ -91,11 +93,12 @@ const LearningSection: React.FC = () => {
           <div className="mx-4 mb-4">
             {/* SORT BUTTON  */}
             <div className="flex text-[15px] my-2 cursor-pointer">
-              <Dropdown
+              <SortDropdown
                 options={sortOptions}
                 onChange={handleSortOptionChange}
-                buttonText={selectedOption ?? 'Sort by Increasing progress'}
+                buttonText={selectedOption ?? 'A - Z'}
                 buttonIcon={<FilterIcon />}
+                buttonClass="w-auto h-[25px] text-[14px]"
               />
             </div>
 


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/board/LMS?selectedIssueKey=LMS-646&assignee=417519

## Defintion of Don
- [x] "Sort by Increasing Progress" should not appear from the Learners tab in Courses and Learning paths
- [x] check if there are no errors or unexpected behaviors caused by the commented out code
- [x] "See all learners" button is functional and performs the intended action
- [x] Filters button is visually aligned and easily accessible for both functionalities
- [x] learner names are displayed in ascending order (A - Z) by default

## Steps to reproduce
docker-compose up
visit url: http://[localhost:3000/trainer/courses/3](http://localhost:3000/trainer/courses/3)
http://[localhost:3000/trainer/learning-paths/3](http://localhost:3000/trainer/learning-paths/3)

## Affected Components / Functionalities / Page
sections/courses/LearningSection/index.tsx
sections/learning-paths/LearningSection.tsx

## Test Cases


## Notes
Use the SortDropdown component instead of dropdown component for both course and learning paths learner section  [pls comment if I should delete the other 1]

## Screenshots
![pr29](https://github.com/framgia/sph-lms/assets/110363969/79a341a6-2d69-4cf3-89d3-a5e580ed3b42)
