### PR TITLE
[LMS-650] [Markup] Trainer Dashboard

### DIFF
--- a/client/src/pages/_document.tsx
+++ b/client/src/pages/_document.tsx
@@ -1,5 +1,5 @@
+import { Head, Html, Main, NextScript } from 'next/document';
 import React from 'react';
-import { Html, Head, Main, NextScript } from 'next/document';
 
 const Document: React.FunctionComponent = () => {
   return (

--- a/client/src/pages/trainer/dashboard/index.tsx
+++ b/client/src/pages/trainer/dashboard/index.tsx
@@ -1,0 +1,64 @@
+import Tabs from '@/src/shared/components/Tabs';
+import Tab from '@/src/shared/components/Tabs/Tab';
+import ArrowIcon from '@/src/shared/icons/ArrowIcon';
+import Link from 'next/link';
+import { Fragment } from 'react';
+
+const trainer = {
+  first_name: 'John',
+};
+
+const DashboardPage: React.FC = () => {
+  return (
+    <Fragment>
+      <div className="flex flex-col justify-center items-center gap-24 w-full pt-24">
+        <div className="flex flex-col gap-2 justify-center items-center">
+          <div className="font-semibold text-[32px] leading-[40px] font-lora">
+            <span className="text-dark">Welcome back, </span>
+            <span className="text-red">Trainer {trainer.first_name}</span>
+          </div>
+          <div className="flex gap-1 text-sm">
+            <span className="font-normal">See the progress of your trainees: </span>
+            <Link
+              href="/trainer/trainees"
+              className="font-medium underline underline-offset-4 decoration-2 decoration-blue"
+            >
+              Trainees List
+            </Link>
+          </div>
+        </div>
+        <div className="flex border-t-[0.5px] w-full justify-center items-start">
+          <div className="flex flex-col gap-4 p-4 container w-[962px]">
+            <span className="text-dark font-semibold text-2xl font-lora">Overview</span>
+            <Tabs>
+              <Tab title="My Trainees">
+                <div>Trainees Section</div>
+              </Tab>
+              <Tab title="My Courses">
+                <div>Courses Section</div>
+              </Tab>
+              <Tab title="My Learning Paths">
+                <div>Learning Paths Section</div>
+              </Tab>
+            </Tabs>
+          </div>
+          <div className="flex flex-col p-2 gap-1 text-dark text-sm">
+            <span className="font-medium">Quick Links</span>
+            <div className="flex flex-col font-normal">
+              <Link href="/trainer/courses/create" className="flex">
+                <ArrowIcon className="transform rotate-180" />
+                <span>New course</span>
+              </Link>
+              <Link href="/trainer/learning-paths/create" className="flex">
+                <ArrowIcon className="transform rotate-180" />
+                <span>New learning path</span>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Fragment>
+  );
+};
+
+export default DashboardPage;

--- a/client/src/shared/utils/navBarList.ts
+++ b/client/src/shared/utils/navBarList.ts
@@ -1,5 +1,5 @@
 export const navItems = [
-  { url: '/dashboard', text: 'Dashboard' },
+  { url: '/trainer/dashboard', text: 'Dashboard' },
   { url: '/trainer/courses', text: 'Courses' },
   { url: '/trainer/learning-paths', text: 'Learning Paths' },
 ];

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  font-family: 'Inter', sans-serif;
+}
+
 progress[value]::-webkit-progress-bar {
   background-color: theme('colors.lightGray2');
   border-radius: theme('borderRadius.lg');

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -15,6 +15,10 @@ module.exports = {
       inter: ['Inter'],
     },
     extend: {
+      fontFamily: {
+        lora: ['Lora', 'serif'],
+        inter: ['Inter', 'sans-serif'],
+      },
       colors: {
         blueGray: '#E0E5ED',
         lightBlue: '#325184',


### PR DESCRIPTION
## Issue Link
[LMS-650 [Markup] Trainer Dashboard](https://framgiaph.backlog.com/view/LMS-650)

## Defintion of Done
- [x] You should be able to see the Trainer Dashboard page with working tabs and quick links

## Steps to reproduce
1. Login as trainer
2. Go to `http://localhost:3000/trainer/dashboard`

## Affected Components / Functionalities / Page
- Navbar list
- globals.css
- Tailwind config

## Test Cases
_will update soon..._

## Notes
- Added Lora and Inter fonts

## Screenshots
![image](https://github.com/framgia/sph-lms/assets/116238730/8651b890-78c2-4c4f-98e4-f36d055b97a6)
