### PR TITLE
[LMS 628] [API/Integration] Learning Path Detail - Sort Learners in Learners Tab

### DIFF
--- a/api/app_sph_lms/api/serializer/learning_path_serializer.py
+++ b/api/app_sph_lms/api/serializer/learning_path_serializer.py
@@ -1,10 +1,10 @@
 import random
 
+from app_sph_lms.api.serializer.category_serializer import CategorySerializer
+from app_sph_lms.api.serializer.course_serializer import CourseSerializer
 from app_sph_lms.models import (Category, Course, LearningPath,
                                 LearningPathCourse, User)
 from rest_framework import serializers
-from app_sph_lms.api.serializer.course_serializer import CourseSerializer
-from app_sph_lms.api.serializer.category_serializer import CategorySerializer
 from rest_framework.pagination import PageNumberPagination
 
 
@@ -129,8 +129,19 @@ class LearningPathTraineeSerializer(serializers.ModelSerializer):
                     "true"
                 )
 
+        sortingOption = self.context[
+                'request'
+            ].query_params.get(
+                    'sort_by',
+                    "A - Z",
+                )
+
         if is_enrolled == "true":
-            course_trainees = obj.trainee.all()
+            if sortingOption == "A - Z":
+                learning_path_trainees = obj.trainee.order_by('first_name')
+            elif sortingOption == "Z - A":
+                learning_path_trainees = obj.trainee.order_by('-first_name')
+
             data = [
                         {
                             "id": trainee.id,
@@ -139,7 +150,7 @@ class LearningPathTraineeSerializer(serializers.ModelSerializer):
                             "email": trainee.email,
                             "progress": random.randint(0, 100),
                         }
-                        for trainee in course_trainees
+                        for trainee in learning_path_trainees
                     ]
         else:
             # no filters, base logic to get all trainees,

--- a/client/src/sections/learning-paths/LearnersSection/index.tsx
+++ b/client/src/sections/learning-paths/LearnersSection/index.tsx
@@ -1,24 +1,24 @@
-import React, { Fragment, useEffect, useState } from 'react';
-import ShowIcon from '@/src/shared/icons/ShowIcon';
-import ProgressPercentage from '@/src/shared/components/ProgressPercentage';
-import FilterIcon from '@/src/shared/icons/FilterIcon';
 import SortDropdown, {
   type SortOption,
 } from '@/src/shared/components/Dropdown/SortDropdown/SortDropdown';
+import ProgressPercentage from '@/src/shared/components/ProgressPercentage';
+import FilterIcon from '@/src/shared/icons/FilterIcon';
+import ShowIcon from '@/src/shared/icons/ShowIcon';
+import React, { Fragment, useEffect, useState } from 'react';
 // import ArrowIcon from '@/src/shared/icons/ArrowIcon';
-import AddLearnerModal from '../../../shared/components/Modal/AddLearnerModal';
-import Button from '@/src/shared/components/Button';
-import { useAppDispatch, useAppSelector } from '@/src/redux/hooks';
-import { useRouter } from 'next/router';
 import {
   addTrainees,
   resetTraineesList,
   seeMoreTrainees,
 } from '@/src/features/learning-path/learnerSlice';
+import { useAppDispatch, useAppSelector } from '@/src/redux/hooks';
 import { useGetLearningPathLearnerQuery } from '@/src/services/traineeAPI';
+import Button from '@/src/shared/components/Button';
+import { useRouter } from 'next/router';
+import AddLearnerModal from '../../../shared/components/Modal/AddLearnerModal';
 
 const LearningPathLearnersSection: React.FC = () => {
-  const [selectedSortOption, setSelectedSortOption] = useState('');
+  const [selectedSortOption, setSelectedSortOption] = useState('A - Z');
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const dispatch = useAppDispatch();
   const router = useRouter();

--- a/client/src/services/traineeAPI.ts
+++ b/client/src/services/traineeAPI.ts
@@ -25,12 +25,13 @@ export const getCourseTrainee = createApi({
       providesTags: ['CourseTrainee'],
     }),
     getLearningPathLearner: builder.query({
-      query: ({ courseId, isEnrolled, searchQuery, pageNumber }) => ({
+      query: ({ courseId, isEnrolled, searchQuery, pageNumber, selectedSortOption }) => ({
         url: `learning-path/${courseId}/trainee`,
         params: {
           is_enrolled: isEnrolled,
           search: searchQuery,
           page: pageNumber,
+          sort_by: selectedSortOption,
         },
       }),
       providesTags: ['LearningPathTrainee'],


### PR DESCRIPTION
## Issue Link
[LMS-628 [API/Integration] Learning Path Detail - Sort Learners in Learners Tab](https://framgiaph.backlog.com/view/LMS-628)

## Defintion of Done

- [x] Trainer should be able to sort learners alphabetically.

## Steps to reproduce
Ensure that you have existing Learning Paths and Users (trainees) in the db

1. Go to `http://localhost:3000/trainer/learning-paths/1`.
2. Click on Learners tab.
3. If there are no learners yet, add more than one.
4. Click on the Sort button.

## Affected Components / Functionalities / Page
BE
- Learning Path serializer
- Trainee view

FE
- `traineeAPI` service
- Learning Path Detail - Learners Tab

## Test Cases
_will update soon..._

## Notes
n/a

## Screenshots
![image](https://github.com/framgia/sph-lms/assets/116238730/21f17332-0f53-434b-a7f4-84cf9ade8b70)
![image](https://github.com/framgia/sph-lms/assets/116238730/8a7451cc-43bb-4a5a-8651-5f6e498b86dd)

