### PR TITLE
[LMS-662] [API/Integration] My Learning Paths tab

### DIFF
--- a/api/app_sph_lms/api/serializer/trainer_serializer.py
+++ b/api/app_sph_lms/api/serializer/trainer_serializer.py
@@ -1,6 +1,6 @@
 from app_sph_lms.api.serializer.course_serializer import CourseSerializer
 from app_sph_lms.api.serializer.user_serializer import UserSerializer
-from app_sph_lms.models import Course, Trainer, User
+from app_sph_lms.models import Course, Trainer, User, LearningPath
 from rest_framework import serializers
 
 
@@ -62,3 +62,23 @@ class TrainerTraineeSerializer(serializers.ModelSerializer):
             }
             return progress
         return None
+    
+class TrainerCourseSerializer(serializers.ModelSerializer):
+    lesson_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Course
+        fields = ("id", "name", "lesson_count")
+
+    def get_lesson_count(self, obj):
+        return obj.lessons.count()
+
+class TrainerLearningPathSerializer(serializers.ModelSerializer):
+    course_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = LearningPath
+        fields = ["id", "name", "course_count"]
+
+    def get_course_count(self, instance):
+        return instance.courses.all().count()

--- a/api/app_sph_lms/api/urls.py
+++ b/api/app_sph_lms/api/urls.py
@@ -8,7 +8,7 @@ from app_sph_lms.api.view.learning_path_view import (LearningPathDetail,
                                                      LearningPathList)
 from app_sph_lms.api.view.trainee_view import (CourseTraineeViewSet,
                                                LearningPathTraineeViewSet, TrainerTraineeList)
-from app_sph_lms.api.view.trainer_view import TrainerCoursesList
+from app_sph_lms.api.view.trainer_view import TrainerCoursesList, TrainerLearningPathList
 from app_sph_lms.api.view.user_view import (CompanyUsersViewSet, TraineeList,
                                             UserDetail)
 from django.urls import path
@@ -102,4 +102,9 @@ urlpatterns = [
         TrainerCoursesList.as_view(),
         name="learning-path-detail"
     ),
+    path(
+        'trainer/learning-path',
+        TrainerLearningPathList.as_view(),
+        name="trainer-learning-path-list"
+    )
 ]

--- a/api/app_sph_lms/api/view/trainer_view.py
+++ b/api/app_sph_lms/api/view/trainer_view.py
@@ -1,7 +1,7 @@
 from app_sph_lms.api.serializer.trainer_serializer import \
-    TrainerCourseSerializer
+    TrainerCourseSerializer, TrainerLearningPathSerializer
 from app_sph_lms.api.view.course_view import LargeResultsSetPagination
-from app_sph_lms.models import Course
+from app_sph_lms.models import Course, LearningPath
 from rest_framework import generics
 
 
@@ -15,3 +15,14 @@ class TrainerCoursesList(generics.ListAPIView):
 
     def get_queryset(self):
         return Course.objects.filter(author=self.request.user)
+
+class TrainerLearningPathList(generics.ListCreateAPIView):
+    queryset = LearningPath.objects.filter(is_active=True)
+    serializer_class = TrainerLearningPathSerializer
+    pagination_class = LargeResultsSetPagination
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        queryset = queryset.filter(author=self.request.user)
+
+        return queryset

--- a/client/src/features/trainer/trainerLearningPathSlice.ts
+++ b/client/src/features/trainer/trainerLearningPathSlice.ts
@@ -1,0 +1,40 @@
+import type { TrainerLearningPath } from '@/src/shared/utils';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+
+interface TrainerLearningPathData {
+  learningPaths: TrainerLearningPath[];
+  page: number;
+}
+
+const initialState: TrainerLearningPathData = {
+  learningPaths: [],
+  page: 1,
+};
+
+const trainerLearningPathSlice = createSlice({
+  name: 'trainerLearningPaths',
+  initialState,
+  reducers: {
+    addTrainerLearningPaths: (state, action: PayloadAction<TrainerLearningPath[]>) => {
+      const newLearningPaths = action.payload.filter((learningPath) => {
+        return !state.learningPaths.some(
+          (existingLearningPath) => existingLearningPath.id === learningPath.id
+        );
+      });
+      state.learningPaths.push(...newLearningPaths);
+    },
+    seeMoreLearningPaths: (state) => {
+      state.page += 1;
+    },
+    resetTrainerLearningPaths: (state) => {
+      state.learningPaths = [];
+      state.page = 1;
+    },
+  },
+});
+
+export const { addTrainerLearningPaths, seeMoreLearningPaths, resetTrainerLearningPaths } =
+  trainerLearningPathSlice.actions;
+
+export default trainerLearningPathSlice.reducer;

--- a/client/src/pages/trainer/learning-paths/create/index.tsx
+++ b/client/src/pages/trainer/learning-paths/create/index.tsx
@@ -79,8 +79,8 @@ const LearningPathCreate = (): JSX.Element => {
             const property = Object.keys(data)[0];
             throw new Error(data[property][0]);
           } else {
-            alertSuccess('Learning path created successfully!');
             await push('/trainer/learning-paths');
+            alertSuccess('Learning path created successfully!');
             dispatch(reset());
           }
         } catch (e: any) {

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -11,6 +11,7 @@ import lessonModalsReducer from '../features/course/lessonModalsSlice';
 import courseModalsReducer from '../features/learning-path/courseModalsSlice';
 import learningPathLearnerReducer from '../features/learning-path/learnerSlice';
 import learningPathReducer from '../features/learning-path/learningPathSlice';
+import trainerLearningPathReducer from '../features/trainer/trainerLearningPathSlice';
 import stepperReducer from '../features/stepper/stepperSlice';
 import tabReducer from '../features/tab/tabSlice';
 import trainerCourseReducer from '../features/trainer/trainerCourseSlice';
@@ -26,12 +27,14 @@ export const store = configureStore({
     trainerCourse: trainerCourseReducer,
     lessonModals: lessonModalsReducer,
     learningPath: learningPathReducer,
+    trainerLearningPath: trainerLearningPathReducer,
     courseModals: courseModalsReducer,
     stepper: stepperReducer,
     tab: tabReducer,
     trainerDashboard: dashboardTraineeReducer,
     [getCourse.reducerPath]: getCourse.reducer,
     [getCourseTrainee.reducerPath]: getCourseTrainee.reducer,
+    [getTrainer.reducerPath]: getTrainer.reducer,
     [getCategory.reducerPath]: getCategory.reducer,
     [getLearningPath.reducerPath]: getLearningPath.reducer,
     [getTrainer.reducerPath]: getTrainer.reducer,
@@ -42,6 +45,7 @@ export const store = configureStore({
     })
       .concat(getCourse.middleware)
       .concat(getCourseTrainee.middleware)
+      .concat(getTrainer.middleware)
       .concat(getCategory.middleware)
       .concat(getLearningPath.middleware)
       .concat(getTrainer.middleware),

--- a/client/src/sections/dashboard/LearningPathSection.tsx
+++ b/client/src/sections/dashboard/LearningPathSection.tsx
@@ -1,41 +1,59 @@
+import {
+  addTrainerLearningPaths,
+  resetTrainerLearningPaths,
+  seeMoreLearningPaths,
+} from '@/src/features/trainer/trainerLearningPathSlice';
+import { useAppDispatch, useAppSelector } from '@/src/redux/hooks';
+import { useGetTrainerLearningPathsQuery } from '@/src/services/trainerAPI';
 import DashboardCard from '@/src/shared/components/Card/DashboardCard';
 import ShowIcon from '@/src/shared/icons/ShowIcon';
+import type { TrainerLearningPath } from '@/src/shared/utils';
+import React, { useEffect } from 'react';
 
 const LearningPathSection = (): JSX.Element => {
-  const cardsData: any = [];
-  for (let i = 1; i <= 10; i++) {
-    cardsData.push({
-      id: i,
-      title: `Vue Mastery ${i}`,
-      subText: '3 Courses',
-    });
-  }
+  const dispatch = useAppDispatch();
+  const { learningPaths, page } = useAppSelector((state) => state.trainerLearningPath);
+  const { data: { results: trainerLearningPaths = [], totalPages = 0 } = {}, isLoading } =
+    useGetTrainerLearningPathsQuery({ page, pageSize: 9 });
+
+  useEffect(() => {
+    if (!isLoading && trainerLearningPaths) {
+      dispatch(addTrainerLearningPaths(trainerLearningPaths));
+    }
+  }, [trainerLearningPaths]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(resetTrainerLearningPaths());
+    };
+  }, []);
 
   return (
-    <div className="p-4 mt-[-1rem]">
-      {cardsData.length ? (
-        <div className="flex flex-col gap-4">
-          <span className="text-xs text-neutral-disabled">Ranked by progress %</span>
-          <div className="grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {cardsData.map((card: any) => (
-              <DashboardCard
-                key={card.id}
-                title={card.title}
-                subText={card.subText}
-                link={`/trainer/learning-paths/${card.id}`}
-              />
-            ))}
-          </div>
-          <div className="flex gap-1">
-            <ShowIcon />
-            <span className="text-xs underline underline-offset-4 cursor-pointer">
-              See more Learning Paths
-            </span>
-          </div>
-        </div>
-      ) : (
-        <div className="flex items-center justify-center text-sm text-neutral-disabled">
-          No learning paths to show
+    <div className="mb-20">
+      <span className="text-xs text-neutral-disabled pl-5">Ranked by Progress %</span>
+      <div className="grid grid-cols-3 gap-4 mx-5 mt-5">
+        {learningPaths.map((learningPath: TrainerLearningPath) => (
+          <DashboardCard
+            key={learningPath.id}
+            title={learningPath.name}
+            subText={`${learningPath.course_count} ${
+              learningPath.course_count === 1 ? 'course' : 'courses'
+            }`}
+            link={`learning-paths/${learningPath.id}`}
+          />
+        ))}
+      </div>
+      {page < totalPages && (
+        <div className="flex gap-1 pt-4 pl-4">
+          <ShowIcon />
+          <span
+            className="text-xs underline underline-offset-4 cursor-pointer"
+            onClick={() => {
+              dispatch(seeMoreLearningPaths());
+            }}
+          >
+            See more learning paths
+          </span>
         </div>
       )}
     </div>

--- a/client/src/services/trainerAPI.ts
+++ b/client/src/services/trainerAPI.ts
@@ -1,8 +1,13 @@
-import type { TrainerCourse } from '@/src/shared/utils';
+import type { TrainerCourse, TrainerLearningPath } from '@/src/shared/utils';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 interface CourseList {
   results: TrainerCourse[];
+  totalPages: number;
+}
+
+interface LearningPathList {
+  results: TrainerLearningPath[];
   totalPages: number;
 }
 
@@ -21,7 +26,16 @@ export const getTrainer = createApi({
         },
       }),
     }),
+    getTrainerLearningPaths: builder.query<LearningPathList, { page: number; pageSize?: number }>({
+      query: ({ page, pageSize }) => ({
+        url: 'trainer/learning-path',
+        params: {
+          page,
+          page_size: pageSize,
+        },
+      }),
+    }),
   }),
 });
 
-export const { useGetTrainerCourseQuery } = getTrainer;
+export const { useGetTrainerCourseQuery, useGetTrainerLearningPathsQuery } = getTrainer;

--- a/client/src/shared/components/Tabs/index.tsx
+++ b/client/src/shared/components/Tabs/index.tsx
@@ -39,6 +39,7 @@ const Tabs: FC<TabsProps> = ({ children }) => {
       dispatch(reset());
     });
   }, []);
+
   return (
     <Fragment>
       <div className="hidden md:flex mb-4 border-b">

--- a/client/src/shared/utils/interface.ts
+++ b/client/src/shared/utils/interface.ts
@@ -199,13 +199,16 @@ export interface CourseData {
   course: CourseCollection;
 }
 
-export interface LearningPath {
+export interface TrainerLearningPath {
   id: number;
   name: string;
+  course_count: number;
+}
+
+export interface LearningPath extends TrainerLearningPath {
   description: string;
   image: string;
   ratings: number;
-  course_count: number;
   courses: Course[];
   category: CourseCategory[];
   is_active: boolean;


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/LMS-662

## Definition of Done
- [x] Load the initial page of learning paths and verify that the API response includes field as true
- [x] Number of learning paths per page matches the desired pagination limit
- [x] Loader or load more button to fetch the next page of learning paths

## Steps to reproduce
Go to `localhost:3000/trainer/dashboard`
Click the `My Learning Paths` tab

## Affected Components / Functionalities / Page
- `LearningPathSection`
- `Tabs`
- `store`

## Test Cases
_will update soon..._

## Notes
- **[FIXED]** Encountered a bug in the `Tabs` component where the `activeTab` is not reset when the page changes (See attachment below)
- Used `pageSize = 3` for demo purposes. Reverted back to `9` before commit

## Screenshots
[LMS-662.webm](https://github.com/framgia/sph-lms/assets/111732984/6f343fe9-15ef-4155-9ec6-3889dbe0a337)
