### PR TITLE
[LMS-680][MARKUP] Trainee Dashboard

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8
 
 WORKDIR /api/app
 
-RUN apt-get update && apt-get install -y netcat
+RUN apt-get update && apt-get install -y netcat-traditional
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/client/src/pages/trainee/dashboard/index.tsx
+++ b/client/src/pages/trainee/dashboard/index.tsx
@@ -1,0 +1,47 @@
+import Tabs from '@/src/shared/components/Tabs';
+import Tab from '@/src/shared/components/Tabs/Tab';
+import Link from 'next/link';
+import { Fragment } from 'react';
+import { type CustomSession } from '@/src/shared/utils/interface';
+import { useSession } from 'next-auth/react';
+
+const DashboardPage: React.FC = () => {
+  const { data } = useSession();
+  const session = data as CustomSession;
+
+  return (
+    <Fragment>
+      <div className="flex flex-col justify-center items-center gap-24 w-full pt-24">
+        <div className="flex flex-col gap-2 justify-center items-center">
+          <div className="font-semibold text-[32px] leading-[40px] font-lora">
+            <span className="text-dark">Welcome back, </span>
+            <span className="text-red">Trainee {session?.user?.first_name}</span>
+          </div>
+          <div className="flex gap-1 text-sm">
+            <span className="font-normal">See where you left off: </span>
+            <Link
+              href="#"
+              className="font-medium underline underline-offset-4 decoration-2 decoration-blue"
+            >
+              MERN Stack
+            </Link>
+          </div>
+        </div>
+        <div className="flex border-t-[0.5px] w-full justify-center items-start">
+          <div className="flex flex-col gap-4 p-4 container w-[962px]">
+            <Tabs>
+              <Tab title="My Courses">
+                <div>Trainee Courses Section here</div>
+              </Tab>
+              <Tab title="My Learning Paths">
+                <div>Trainee Learning path Section here</div>
+              </Tab>
+            </Tabs>
+          </div>
+        </div>
+      </div>
+    </Fragment>
+  );
+};
+
+export default DashboardPage;

--- a/client/src/pages/trainer/dashboard/index.tsx
+++ b/client/src/pages/trainer/dashboard/index.tsx
@@ -4,17 +4,10 @@ import TraineesSection from '@/src/sections/dashboard/TraineesSection';
 import Tabs from '@/src/shared/components/Tabs';
 import Tab from '@/src/shared/components/Tabs/Tab';
 import ArrowIcon from '@/src/shared/icons/ArrowIcon';
-import type { Session } from 'next-auth';
+import { type CustomSession } from '@/src/shared/utils/interface';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { Fragment } from 'react';
-
-interface CustomSession extends Session {
-  user: {
-    name?: string;
-    first_name?: string;
-  };
-}
 
 const DashboardPage: React.FC = () => {
   const { data } = useSession();

--- a/client/src/shared/utils/interface.ts
+++ b/client/src/shared/utils/interface.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/array-type */
 import { type ReactElement } from 'react';
-import type { User as NextAuthUser } from 'next-auth';
+import type { User as NextAuthUser, Session } from 'next-auth';
 
 export interface CourseDetails {
   id: string;
@@ -223,4 +223,11 @@ export interface TrainerCourse {
 export interface AuthenticatedUser extends NextAuthUser {
   accessToken?: string;
   refreshToken?: string;
+}
+
+export interface CustomSession extends Session {
+  user: {
+    name?: string;
+    first_name?: string;
+  };
 }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/board/LMS?selectedIssueKey=LMS-680&assignee=417519

## Defintion of Done
Create the trainee dashboard in /trainee/dashboard including the tabs.
Tabs can have a simple message like tab1, tab2

## Steps to reproduce
`docker-compose up`
visit url:[ http://[localhost:3000/trainee/dashboard
](http://localhost:3000/trainee/dashboard)
## Affected Components / Functionalities / Page
pages/trainee/dashboard/index.tsx

## Test Cases


## Notes


## Screenshots
![image](https://github.com/framgia/sph-lms/assets/110363969/c2db9210-95a6-45f4-8fe1-db56fd18e0b2)
