### PR TITLE
[LMS-674][Course][Content Tab] Content Width and Lesson Link

### DIFF
--- a/client/src/sections/courses/ContentSection.tsx
+++ b/client/src/sections/courses/ContentSection.tsx
@@ -4,19 +4,29 @@ import Iframe from '@/src/shared/components/Iframe';
 import SidebarContent from '@/src/shared/components/SidebarContent';
 import SideBar from '@/src/shared/components/SidebarContent/SideBar';
 import type { CourseData } from '@/src/shared/utils';
+import { isYoutubeLink } from '@/src/shared/utils/helpers';
+import Button from '@/src/shared/components/Button';
 
 const ContentSection: React.FunctionComponent<CourseData> = ({ course }: CourseData) => {
   return (
     <Fragment>
-      <div className="flex">
+      <div className="flex flex-grow h-full">
         {course?.lessons?.length > 0 ? (
           <SidebarContent>
             {course?.lessons?.map((col) => (
               <SideBar title={col.title} key={col.id}>
-                <div className="ml-7 flex-grow w-full">
+                <div className="ml-7">
                   <div className="text-20 font-semibold text-textGray">{col.title}</div>
                   <div className="py-3">
-                    <Iframe src={col.link} className="border w-full" />
+                    {isYoutubeLink(col.link) ? (
+                      <Iframe src={col.link} className="w-[946px] h-[554px]" />
+                    ) : (
+                      <Button
+                        text="Open Link"
+                        buttonClass="border border-red text-red !font-medium text-[14px] px-[18px] py-[6.5px] font-inter m-2 ml-5"
+                        onClick={() => window.open(col.link)}
+                      />
+                    )}
                   </div>
                 </div>
               </SideBar>

--- a/client/src/shared/components/Iframe/index.tsx
+++ b/client/src/shared/components/Iframe/index.tsx
@@ -6,6 +6,7 @@ export interface IframeProps {
   width?: string;
   height?: string;
   title?: string;
+  allowFullScreen?: boolean;
 }
 
 const Iframe: React.FunctionComponent<IframeProps> = ({
@@ -13,7 +14,8 @@ const Iframe: React.FunctionComponent<IframeProps> = ({
   className,
   width,
   height,
-  title
+  title,
+  allowFullScreen,
 }: IframeProps) => {
   return (
     <div>
@@ -23,6 +25,7 @@ const Iframe: React.FunctionComponent<IframeProps> = ({
         height={height}
         src={src}
         title={title}
+        allowFullScreen
       ></iframe>
     </div>
   );
@@ -32,7 +35,8 @@ Iframe.defaultProps = {
   className: '',
   width: '100%',
   height: '600',
-  title: ''
+  title: '',
+  allowFullScreen: true,
 };
 
 export default Iframe;

--- a/client/src/shared/components/SidebarContent/index.tsx
+++ b/client/src/shared/components/SidebarContent/index.tsx
@@ -1,12 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-indexed-object-style */
-import React, {
-  Children,
-  type FC,
-  Fragment,
-  type ReactElement,
-  useEffect,
-  useState
-} from 'react';
+import React, { Children, type FC, Fragment, type ReactElement, useEffect, useState } from 'react';
 import { type ChildElementObject } from '../../utils/interface';
 import { type SideBarProps } from './SideBar';
 
@@ -24,12 +17,12 @@ const SidebarContent: FC<SidebarContentProps> = ({ children }) => {
     Children.map(children, (child, index) => {
       if (
         Object.hasOwnProperty.call(child.type, 'name') &&
-          Object.getOwnPropertyDescriptors(child.type).name?.value === 'SideBar'
+        Object.getOwnPropertyDescriptors(child.type).name?.value === 'SideBar'
       ) {
         childrenListObj[index] = {
           id: index,
           title: child.props.title,
-          childContent: child
+          childContent: child,
         };
       }
     });
@@ -42,29 +35,27 @@ const SidebarContent: FC<SidebarContentProps> = ({ children }) => {
   }, [children, activeTab]);
 
   return (
-      <Fragment>
-        <div className="hidden md:flex">
-          <div className="flex flex-col  font-medium text-[14px] text-gray2 capitalize bg-gray1 w-[300px] ">
-            {Object.values(childrenList).map(({ title, id }) => (
-              <div
-                key={id}
-                className={`${
-                  activeTab !== id
-                    ? 'p-2'
-                    : 'bg-lightRed border-red border-r-[2px] p-2 text-textGray'
-                } cursor-pointer flex pointer-events-auto w-full pl-4`}
-                onClick={() => {
-                  setActiveTab(id);
-                }}
-              >
-                {title}
-              </div>
-            ))}
-          </div>
+    <Fragment>
+      <div className="hidden md:flex">
+        <div className="flex-col font-medium text-[14px] text-gray2 capitalize bg-gray1 w-[300px] h-screen">
+          {Object.values(childrenList).map(({ title, id }) => (
+            <div
+              key={id}
+              className={`${
+                activeTab !== id ? 'p-2' : 'bg-lightRed border-red border-r-[2px] p-2 text-textGray'
+              } cursor-pointer flex pointer-events-auto w-full pl-4`}
+              onClick={() => {
+                setActiveTab(id);
+              }}
+            >
+              {title}
+            </div>
+          ))}
         </div>
+      </div>
 
-        <div>{activeTab !== null && childrenList[activeTab]?.childContent}</div>
-      </Fragment>
+      <div>{activeTab !== null && childrenList[activeTab]?.childContent}</div>
+    </Fragment>
   );
 };
 export default SidebarContent;

--- a/client/src/shared/utils/helpers.ts
+++ b/client/src/shared/utils/helpers.ts
@@ -43,3 +43,7 @@ export const isAuthorized = (is_trainer: boolean, pathname: string): boolean => 
   const regex = new RegExp(`^/(${slug}.+)`);
   return regex.test(pathname);
 };
+
+export const isYoutubeLink = (link: string): boolean => {
+  return link.startsWith('https://www.youtube.com');
+};

--- a/client/src/shared/utils/helpers.ts
+++ b/client/src/shared/utils/helpers.ts
@@ -45,5 +45,7 @@ export const isAuthorized = (is_trainer: boolean, pathname: string): boolean => 
 };
 
 export const isYoutubeLink = (link: string): boolean => {
-  return link.startsWith('https://www.youtube.com');
+  const regex =
+    /^(?:https?:\/\/)?(?:m\.|www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/;
+  return regex.test(link);
 };


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/board/LMS?selectedIssueKey=LMS-674&assignee=417519

## Defintion of Done
Fix content material width.
For rendering the content, we have 2 approach:
- if the link is youtube, display it in Iframe
- if the link is udemy, render a button instead to redirect in that link.

## Steps to reproduce
docker-compose up

## Affected Components / Functionalities / Page
Button Component
Course Detail Page
Sidebar Component


## Test Cases
_will update soon..._

## Notes
Create new course and add lesson link with youtube embed and add lesson with udemy link to test.

## Screenshots
![pr30](https://github.com/framgia/sph-lms/assets/110363969/f669bbc3-41c4-4fbd-870d-ec26d7a9e2d0)
