### PR TITLE
[LMS-693]-[Bugfix] Make Button Style Uniform

### DIFF
--- a/client/src/pages/trainer/courses/index.tsx
+++ b/client/src/pages/trainer/courses/index.tsx
@@ -67,7 +67,7 @@ const CoursesListPage: React.FC = () => {
               />
               <Link
                 href="/trainer/courses/create"
-                className="border border-red text-red text-[14px] rounded-md px-5 py-[6.5px]"
+                className="border border-red text-red text-sm h-9 items-center rounded-md font-medium px-4 py-2"
               >
                 Create a course
               </Link>

--- a/client/src/sections/courses/LearningSection/index.tsx
+++ b/client/src/sections/courses/LearningSection/index.tsx
@@ -80,7 +80,7 @@ const LearningSection: React.FC = () => {
           <div>
             <Button
               text="Add learner"
-              buttonClass="px-4 py-2 text-sm bg-white text-blue-500 border-2 border-red"
+              buttonClass="border border-red text-red text-sm h-9 items-center rounded-md font-medium px-4 py-2"
               textColor="text-red"
               onClick={handleAddMaterialModal}
             />

--- a/client/src/sections/learning-paths/LearnersSection/index.tsx
+++ b/client/src/sections/learning-paths/LearnersSection/index.tsx
@@ -88,7 +88,7 @@ const LearningPathLearnersSection: React.FC = () => {
           <div>
             <Button
               text="Add learner"
-              buttonClass="px-4 py-2 text-sm bg-white text-blue-500 border-2 border-red"
+              buttonClass="border border-red text-red text-sm h-9 items-center rounded-md font-medium px-4 py-2"
               textColor="text-red"
               onClick={handleAddLernerModal}
             />

--- a/client/src/shared/components/Button/EditModeButtons.tsx
+++ b/client/src/shared/components/Button/EditModeButtons.tsx
@@ -28,7 +28,7 @@ const EditModeButtons: FC<EditModeButtonsProps> = ({ editMode, onCancel, onSave,
         <Button
           onClick={onEdit}
           text="Edit settings"
-          buttonClass="border border-red text-red !font-medium text-[14px] px-[18px] py-[6.5px] font-inter"
+          buttonClass="border border-red text-red text-sm h-9 items-center rounded-md font-medium px-4 py-2"
         />
       )}
     </Fragment>


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/LMS-693

## Defintion of Done
[x] - Every buttons uses almost the same styles

## Steps to reproduce
Redirect to the following to see the buttons:
- http://localhost:3000/trainer/courses - Create a course button
- http://localhost:3000/trainer/courses/2 - Learners tab and Settings tab
- http://localhost:3000/trainer/learning-paths - Create learning path button
- http://localhost:3000/trainer/learning-paths/2 - Learning tab and Settings tab


## Affected Components / Functionalities / Page
client/src/pages/trainer/courses/index.tsx
client/src/sections/courses/LearningSection/index.tsx
client/src/sections/learning-paths/LearnersSection/index.tsx
client/src/shared/components/Button/EditModeButtons.tsx


## Screenshots
![image](https://github.com/framgia/sph-lms/assets/110363852/53b39dd1-061a-4d2d-a0f3-f513e70ad02b)
![image](https://github.com/framgia/sph-lms/assets/110363852/b8d35f2c-7f07-444e-abea-78956f0d02a2)
![image](https://github.com/framgia/sph-lms/assets/110363852/df61534d-bcd7-4fc2-8290-60a2eefaa279)
![image](https://github.com/framgia/sph-lms/assets/110363852/f8847d82-d798-486c-a3b4-11502dbc2f10)
![image](https://github.com/framgia/sph-lms/assets/110363852/aba6a1e7-2a55-4f83-ad6d-15a84630a623)
