### PR TITLE
[LMS-691] [BUGFIX] [Course & Learning Path] [Settings Tab] Update Description display and Delete Confirmation Should use Dynamic name

### DIFF
--- a/client/src/sections/courses/SettingsSection/index.tsx
+++ b/client/src/sections/courses/SettingsSection/index.tsx
@@ -117,7 +117,7 @@ const SettingsSection: FC = () => {
           setIsDeleteModalOpen(false);
         }}
         item="course"
-        itemTitle="Vue introduction"
+        itemTitle={values.name}
         onConfirm={handleDelete}
       />
     </Fragment>

--- a/client/src/sections/courses/create/InitialSection.tsx
+++ b/client/src/sections/courses/create/InitialSection.tsx
@@ -8,7 +8,7 @@ import RFTextField from '@/src/shared/components/ReactForm/RFTextField';
 import ExclamationPointIcon from '@/src/shared/icons/ExclamationPointIcon';
 import type { MultiSelectOptionData } from '@/src/shared/utils';
 import Image from 'next/image';
-import { Fragment, useEffect, type FC } from 'react';
+import { Fragment, useEffect, type FC, useRef } from 'react';
 import {
   Controller,
   type FieldErrors,
@@ -24,6 +24,7 @@ interface InitialSectionProps {
 }
 
 const InitialSection: FC<InitialSectionProps> = ({ register, errors, control }) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { values: course, editMode } = useAppSelector((state) => state.course);
   const dispatch = useAppDispatch();
 
@@ -101,10 +102,11 @@ const InitialSection: FC<InitialSectionProps> = ({ register, errors, control }) 
         error={errors && (errors.name?.message as string)}
       />
       <RFTextField
+        ref={textareaRef}
         labelClass="!font-medium"
         label="Description"
         className={`min-w-[70%] max-w-[100%] ${
-          !editMode ? 'border-transparent bg-transparent resize-none h-max' : 'resize'
+          !editMode ? 'border-transparent bg-transparent resize-none overflow-hidden' : 'resize'
         }`}
         readOnly={!editMode}
         defaultValue={course.description}

--- a/client/src/sections/learning-paths/create/InitialSection.tsx
+++ b/client/src/sections/learning-paths/create/InitialSection.tsx
@@ -13,7 +13,7 @@ import ChevronDown from '@/src/shared/icons/ChevronDownIcon';
 import ExclamationPointIcon from '@/src/shared/icons/ExclamationPointIcon';
 import type { MultiSelectOptionData } from '@/src/shared/utils';
 import Image from 'next/image';
-import { Fragment, useEffect } from 'react';
+import { Fragment, useEffect, useRef } from 'react';
 import {
   Controller,
   type FieldErrors,
@@ -36,6 +36,7 @@ const InitialSection = ({
   control,
   showStatus = true,
 }: InitialSectionProps): JSX.Element => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { values: learningPath, editMode } = useAppSelector((state) => state.learningPath);
   const dispatch = useAppDispatch();
 
@@ -117,10 +118,11 @@ const InitialSection = ({
         error={errors && (errors.name?.message as string)}
       />
       <RFTextField
+        ref={textareaRef}
         labelClass="!font-medium"
         label={`${editMode ? 'Description' : 'Description:'}`}
         className={`min-w-[70%] max-w-[100%] ${
-          !editMode ? 'border-transparent bg-transparent resize-none h-max' : 'resize'
+          !editMode ? 'border-transparent bg-transparent resize-none overflow-hidden' : 'resize'
         }`}
         readOnly={!editMode}
         defaultValue={learningPath.description}
@@ -192,7 +194,7 @@ const InitialSection = ({
               onChange={(val) => {
                 dispatch(updateForm({ isActive: val === 'Active' }));
               }}
-              buttonClass='w-fit pr-2'
+              buttonClass="w-fit pr-2"
             />
           </div>
         </div>

--- a/client/src/shared/components/ReactForm/RFTextField/index.tsx
+++ b/client/src/shared/components/ReactForm/RFTextField/index.tsx
@@ -2,8 +2,7 @@
 /* eslint-disable object-shorthand */
 /* eslint-disable react/display-name */
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
-import React from 'react';
-import { forwardRef, type TextareaHTMLAttributes, type LegacyRef } from 'react';
+import { forwardRef, type TextareaHTMLAttributes, useState, useEffect } from 'react';
 import { type UseFormRegisterReturn } from 'react-hook-form';
 
 interface Props extends TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -14,8 +13,22 @@ interface Props extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   labelClass?: string;
 }
 
-const RFTextField = forwardRef((props: Props, ref: LegacyRef<HTMLTextAreaElement>) => {
+const RFTextField = forwardRef<HTMLTextAreaElement, Props>((props, ref) => {
   const { label, register, error, className, labelClass, ...rest } = props;
+
+  const [textareaHeight, setTextareaHeight] = useState('auto');
+
+  useEffect(() => {
+    const newRef = ref as typeof ref & {
+      current: {
+        scrollHeight: number;
+      };
+    };
+
+    if (newRef.current) {
+      setTextareaHeight(`${newRef.current.scrollHeight}px`);
+    }
+  }, [ref]);
 
   const errorAlert = (error: string | boolean): string => {
     return error ? ' border-red' : ' border-gray-300';
@@ -30,7 +43,8 @@ const RFTextField = forwardRef((props: Props, ref: LegacyRef<HTMLTextAreaElement
       )}
       <textarea
         ref={ref}
-        className={`appearance-none border rounded text-sm py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline h-[200px] ${
+        style={{ height: textareaHeight }}
+        className={`appearance-none border rounded text-sm py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline ${
           error !== undefined && errorAlert(error)
         } ${className}`}
         {...register}


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/LMS-691

## Definition of Done
- [x] Description should display the whole text without the scrollbar (for viewing mode only)
- [x] Make sure that the Archive and Delete confirmation using a dynamic name instead of static

## Steps to reproduce
_will update soon..._

## Affected Components / Functionalities / Page
n/a

## Test Cases
_will update soon..._

## Notes
n/a

## Screenshots
![image](https://github.com/framgia/sph-lms/assets/111732984/70107bfc-048b-483f-8890-e646a4b8af28)
![image](https://github.com/framgia/sph-lms/assets/111732984/c6f3e5ad-ab20-448b-acd7-a11aece53b3b)
![image](https://github.com/framgia/sph-lms/assets/111732984/0b40b08a-bca9-4ed0-b0d9-bf68b31bdeaf)
![image](https://github.com/framgia/sph-lms/assets/111732984/0908d64e-6aeb-4a53-94e0-86d350476a56)
