### PR TITLE
[LMS-692] [BUGFIX] [Learning Path Detail Page] Display courses by order & hide drag icon on non-edit mode

### DIFF
--- a/api/app_sph_lms/api/serializer/learning_path_serializer.py
+++ b/api/app_sph_lms/api/serializer/learning_path_serializer.py
@@ -97,7 +97,13 @@ class ExtendedCourse(CourseSerializer):
     order = serializers.SerializerMethodField()
 
     def get_order(self, course):
-        return course.learning_path_course.first().course_order
+        learning_path_id = self.context["request"].parser_context[
+            "kwargs"
+        ].get("pk")
+        learning_path_course = course.learning_path_course.filter(
+            learning_path__id=learning_path_id
+        ).first()
+        return learning_path_course.course_order
 
     class Meta(CourseSerializer.Meta):
         exclude = CourseSerializer.Meta.exclude
@@ -117,7 +123,9 @@ class LearningPathDetailSerializer(serializers.ModelSerializer):
             instance.is_active = is_active
         else:
             instance.name = validated_data.get('name', instance.name)
-            instance.description = validated_data.get('description', instance.description)
+            instance.description = validated_data.get(
+                'description', instance.description
+            )
             instance.image = validated_data.get('image', instance.image)
             if 'category' in validated_data:
                 category_data = validated_data.pop('category')
@@ -125,7 +133,9 @@ class LearningPathDetailSerializer(serializers.ModelSerializer):
 
             if 'courses' in validated_data:
                 courses_data = validated_data.pop('courses')
-                LearningPathCourse.objects.filter(learning_path=instance).delete()
+                LearningPathCourse.objects.filter(
+                    learning_path=instance
+                ).delete()
                 for course_data in courses_data:
                     course = Course.objects.get(id=course_data['course'])
                     course_order = course_data['course_order']

--- a/client/src/sections/learning-paths/create/CourseItem.tsx
+++ b/client/src/sections/learning-paths/create/CourseItem.tsx
@@ -15,6 +15,7 @@ const CourseItem = ({ course }: CourseItemProps): JSX.Element => {
   const { name, lessons } = course;
   return (
     <Collapse
+      editMode={learningPathEditMode}
       label={name}
       onDelete={
         learningPathEditMode

--- a/client/src/shared/components/Collapse/Collapse.tsx
+++ b/client/src/shared/components/Collapse/Collapse.tsx
@@ -8,9 +8,10 @@ export interface collapseProps {
   label: string;
   children: React.ReactNode;
   onDelete?: () => void;
+  editMode?: boolean;
 }
 
-const Collapse: React.FC<collapseProps> = ({ label, children, onDelete }) => {
+const Collapse: React.FC<collapseProps> = ({ label, children, onDelete, editMode = true }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const toggleCollapse = (): void => {
@@ -23,7 +24,7 @@ const Collapse: React.FC<collapseProps> = ({ label, children, onDelete }) => {
     <div className="flex flex-col divide-y border border-neutral-200 rounded-[5px] cursor-pointer">
       <div className="flex p-4 items-center" onClick={toggleCollapse}>
         <div className="flex gap-1 items-center w-full mr-4">
-          <FourDotsIcon />
+          {editMode && <FourDotsIcon />}
           <span className="text-sm flex-1">{label}</span>
           {!!onDelete && (
             <TrashIcon


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/LMS-692

## Defintion of Done

- [x] Courses displayed in Learning Path Detail page should be arranged according to its order.
- [x] Drag icon should not be visible in view mode.

## Steps to reproduce
Go to `http://localhost:3000/trainer/learning-paths/1`
Click on `Content` tab to check the order of courses
Click on `Settings` tab and toggle between edit and view mode to check the visibility of the drag icon

## Affected Components / Functionalities / Page
BE
- Learning Path serializer
- Learning Path view

FE
- client/src/sections/learning-paths/create/CourseItem.tsx
- client/src/shared/components/Collapse/Collapse.tsx

## Test Cases
_will update soon..._

## Notes
n/a

## Screenshots
![image](https://github.com/framgia/sph-lms/assets/116238730/2b3a8d62-80a8-49b8-99b4-b3a5a616cf4c)
![image](https://github.com/framgia/sph-lms/assets/116238730/d7c18313-4274-4fcb-b10b-a2155b862fcd)
![image](https://github.com/framgia/sph-lms/assets/116238730/21499db4-e8be-4c67-866a-c1f7e252b7e0)



