### PR TITLE
[LMS-694] [BUGFIX] [Course & Learning Path] [Settings Tab] Settings Tab details is not showing on visiting another Course/LP coming from another Course/LP

### DIFF
--- a/client/src/pages/trainer/courses/[id]/index.tsx
+++ b/client/src/pages/trainer/courses/[id]/index.tsx
@@ -7,7 +7,6 @@ import Tabs from '@/src/shared/components/Tabs';
 import Tab from '@/src/shared/components/Tabs/Tab';
 import Container from '@/src/shared/layouts/Container';
 import { Fragment, useEffect } from 'react';
-import { useAppDispatch } from '@/src/redux/hooks';
 import { reset } from '@/src/features/course/courseSlice';
 import type { GetServerSideProps, NextApiRequest, NextApiResponse } from 'next';
 import API from '@/src/apis';
@@ -15,12 +14,15 @@ import type { AxiosError } from 'axios';
 import { getServerSession } from 'next-auth';
 import { settings } from '@/src/pages/api/auth/[...nextauth]';
 import type { Course, DBCourse } from '@/src/shared/utils';
+import { useRouter } from 'next/router';
+import { useAppDispatch } from '@/src/redux/hooks';
 
 interface CourseContentProps {
   course: Course | DBCourse;
 }
 
 const CourseContent = ({ course }: CourseContentProps): JSX.Element | undefined => {
+  const router = useRouter();
   const dispatch = useAppDispatch();
 
   const paths = [
@@ -39,6 +41,12 @@ const CourseContent = ({ course }: CourseContentProps): JSX.Element | undefined 
       dispatch(reset(course as DBCourse));
     }
   }, [course]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(reset());
+    };
+  }, [router]);
 
   return (
     <Fragment>

--- a/client/src/pages/trainer/learning-paths/[id]/index.tsx
+++ b/client/src/pages/trainer/learning-paths/[id]/index.tsx
@@ -15,6 +15,7 @@ import { settings } from '@/src/pages/api/auth/[...nextauth]';
 import API from '@/src/apis';
 import type { AxiosError } from 'axios';
 import type { LearningPath } from '@/src/shared/utils';
+import { useRouter } from 'next/router';
 
 interface LearningPathContentProps {
   learningPath: LearningPath;
@@ -23,6 +24,7 @@ interface LearningPathContentProps {
 const LearningPathContent = ({
   learningPath,
 }: LearningPathContentProps): JSX.Element | undefined => {
+  const router = useRouter();
   const dispatch = useAppDispatch();
 
   const paths = [
@@ -41,6 +43,12 @@ const LearningPathContent = ({
       dispatch(reset(learningPath));
     }
   }, [learningPath]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(reset());
+    };
+  }, [router]);
 
   return (
     <Fragment>

--- a/client/src/sections/courses/SettingsSection/index.tsx
+++ b/client/src/sections/courses/SettingsSection/index.tsx
@@ -3,7 +3,7 @@ import AddLessonSection from '../create/AddLessonSection';
 import InitialSection from '../create/InitialSection';
 import Button from '@/src/shared/components/Button';
 import { useAppDispatch, useAppSelector } from '@/src/redux/hooks';
-import { changeEditMode, reset as courseReset } from '@/src/features/course/courseSlice';
+import { changeEditMode } from '@/src/features/course/courseSlice';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { courseSchema } from '@/src/shared/utils/validationSchemas';
@@ -19,7 +19,6 @@ const SettingsSection: FC = () => {
   const { values, editMode } = useAppSelector((state) => state.course);
   const { isTabValid } = useAppSelector((state) => state.tab);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const { asPath, events } = useRouter();
   const dispatch = useAppDispatch();
   useConfirmBeforeLeave(editMode);
   const [deleteCourseMutation] = useDeleteCourseMutation();
@@ -80,14 +79,6 @@ const SettingsSection: FC = () => {
     reset(defaultValues);
   }, [editMode]);
 
-  useEffect(() => {
-    const prevPath = asPath;
-    events?.on('routeChangeComplete', (newPath) => {
-      if (newPath !== prevPath) {
-        dispatch(courseReset());
-      }
-    });
-  }, []);
   return (
     <Fragment>
       <InitialSection register={register} errors={errors} control={control} />

--- a/client/src/sections/learning-paths/settingsSection/index.tsx
+++ b/client/src/sections/learning-paths/settingsSection/index.tsx
@@ -1,8 +1,5 @@
 import { useAppDispatch, useAppSelector } from '@/src/redux/hooks';
-import {
-  changeEditMode,
-  reset as learningPathReset,
-} from '@/src/features/learning-path/learningPathSlice';
+import { changeEditMode } from '@/src/features/learning-path/learningPathSlice';
 import { type FC, Fragment, useEffect, useState } from 'react';
 import InitialSection from '../create/InitialSection';
 import Button from '@/src/shared/components/Button';
@@ -21,7 +18,7 @@ const SettingsSection: FC = () => {
   const { isTabValid } = useAppSelector((state) => state.tab);
   const [isArchiveModalOpen, setIsArchiveModalOpen] = useState(false);
   const [isArchived, setIsArchived] = useState(values.isActive);
-  const { asPath, events, query } = useRouter();
+  const { query } = useRouter();
   const [updateLearningPath] = useUpdateLearningPathMutation();
   const learningPathStatus = isArchived ? 'Archive' : 'Activate';
 
@@ -91,14 +88,6 @@ const SettingsSection: FC = () => {
     reset(defaultValues);
   }, [editMode]);
 
-  useEffect(() => {
-    const prevPath = asPath;
-    events?.on('routeChangeComplete', (newPath) => {
-      if (newPath !== prevPath) {
-        dispatch(learningPathReset());
-      }
-    });
-  }, []);
   return (
     <Fragment>
       <InitialSection register={register} errors={errors} control={control} showStatus={false} />


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/LMS-694

## Definition of Done
- [x] Course / Learning Path details should display every time

## Steps to reproduce
1. Go to course / learning path page (list page)
2. Click course / learning path (e.g.. Course1 / Learning Path1)
3. Switch tab to Settings Tab
4. Go to course / learning path page (list page) again
5. Click different course / learning path (e.g.. Course2 / Learning Path2)
6. Switch tab to Settings Tab
Note: Don't reload the application for the entire duration of replicating the problem.

## Affected Components / Functionalities / Page
- Course detail page
- Learning Path detail page

## Test Cases
_will update soon..._

## Notes
n/a

## Screenshots
[LMS-694.webm](https://github.com/framgia/sph-lms/assets/111732984/eea798be-9899-4510-820e-29e0ada5df52)
