### PR TITLE
[LMS-695][MARKUP] [Course Page] change loading display from Loading..…

### DIFF
--- a/client/src/pages/trainer/courses/index.tsx
+++ b/client/src/pages/trainer/courses/index.tsx
@@ -1,6 +1,7 @@
 import { useGetCoursesQuery } from '@/src/services/courseAPI';
 import Pagination from '@/src/shared/components/Pagination';
 import SearchBar from '@/src/shared/components/SearchBar/SearchBar';
+import Spinner from '@/src/shared/components/Spinner';
 import type { DBCourse } from '@/src/shared/utils';
 import { alertError } from '@/src/shared/utils';
 import Head from 'next/head';
@@ -29,7 +30,7 @@ const CoursesListPage: React.FC = () => {
   }, [search]);
 
   if (isLoading) {
-    return <div>Loading...</div>;
+    return <Spinner />;
   }
 
   if (error) {

--- a/client/src/sections/learning-paths/index.tsx
+++ b/client/src/sections/learning-paths/index.tsx
@@ -1,6 +1,7 @@
 import { useGetLearningPathsQuery } from '@/src/services/learningPathAPI';
 import LearningPathCard from '@/src/shared/components/Card/LearningPathCard';
 import Pagination from '@/src/shared/components/Pagination';
+import Spinner from '@/src/shared/components/Spinner';
 import { alertError, type LearningPath } from '@/src/shared/utils';
 import { Fragment } from 'react';
 
@@ -24,7 +25,7 @@ const LearningPathList = ({
   });
 
   if (isLoading) {
-    return <div>Loading...</div>;
+    return <Spinner />;
   }
 
   if (error) {


### PR DESCRIPTION
…. to Spinner component

## Issue Link
https://framgiaph.backlog.com/view/LMS-695

## Defintion of Done
Change the loading to spinner. Use the reusable Spinner.
Please also check other loading in other pages, change to Spinner if applicable.

## Steps to reproduce
docker-compose up

## Affected Components / Functionalities / Page
Learning Path
Courses

## Test Cases
Check the if the spinning component is rendered when Learning Path or Course is loading

## Notes
n/a

## Screenshots
![pr32](https://github.com/framgia/sph-lms/assets/110363969/dbac05ad-ecff-4636-9cb7-08710caf1bca)
