### PR TITLE
[LMS-701][MARKUP] Refactor Learning Path Design

### DIFF
--- a/client/src/sections/learning-paths/ContentSection/index.tsx
+++ b/client/src/sections/learning-paths/ContentSection/index.tsx
@@ -1,7 +1,8 @@
+import Button from '@/src/shared/components/Button';
 import LearningPathCourseCard from '@/src/shared/components/Card/LearningPathCourseCard';
-import ChevronDown from '@/src/shared/icons/ChevronDownIcon';
 import type { LearningPath } from '@/src/shared/utils';
-import React, { type FC } from 'react';
+import Link from 'next/link';
+import React, { Fragment, useState, type FC } from 'react';
 
 interface LearningPathContentSectionProp {
   learningPath: LearningPath;
@@ -10,21 +11,47 @@ interface LearningPathContentSectionProp {
 const LearningPathContentSection: FC<LearningPathContentSectionProp> = ({
   learningPath,
 }): JSX.Element => {
+  const [selectedCourse, setSelectedCourse] = useState(learningPath.courses[0] || null);
+
+  const handlePreview = (course) => {
+    console.log(course);
+    setSelectedCourse(course);
+  };
   return (
-    <div className="flex flex-col gap-4 mb-16">
-      <div className="flex flex-col gap-2">
-        <span className="text-sm text-dark font-medium">Description:</span>
-        <p className="text-sm">{learningPath?.description}</p>
-      </div>
+    <Fragment>
       <div>
-        {learningPath?.courses.map((course, index) => (
-          <div key={course.id} className="flex flex-col items-center">
-            <LearningPathCourseCard course={course} />
-            {learningPath?.courses.length - 1 !== index && <ChevronDown height={40} width={40} />}
-          </div>
-        ))}
+        <h3 className='text-lg font-bold text-dark mb-2'>Description</h3>
+        <p className='text-sm font-normal text-dark'>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ipsum dolores error id, commodi ex et laborum, possimus voluptatum dolore facilis ullam eaque quae a eligendi asperiores placeat accusantium animi blanditiis? Eaque atque ex autem voluptates suscipit! Modi assumenda eum repudiandae nesciunt inventore dignissimos? Doloribus impedit voluptatem quidem assumenda, aspernatur ea.</p>
       </div>
-    </div>
+      <div className='flex gap-6 mt-4'>
+        <div className='grid gap-4'>
+          {learningPath?.courses.map((course, index) => (
+            <div key={course.id} className="flex flex-col items-center">
+              <LearningPathCourseCard course={course} hasButton={true} isSelected={selectedCourse.id === course.id} onPreviewClick={() => { handlePreview(course); }} />
+            </div>
+          ))}
+        </div>
+        <div className='flex-1 gap-[10px]'>
+          <div className='grid gap-4 border border-neutral-900 p-4 rounded-md'>
+            <div>
+              <h3 className='text-base font-[600] text-dark mb-2'>{selectedCourse.name}</h3>
+              <p className='text-xs font-normal text-disabled'>{selectedCourse.description}</p>
+            </div>
+            <div className='grid gap-1'>
+              <h3 className='text-sm font-[600] text-dark mb-2'>Course Overview</h3>
+              <div>
+                {selectedCourse.lessons.map((lesson) => (
+                  <div key={lesson.id} className='bg-neutral-50 px-4 py-2 text-sm font-[500] text-lightGray3 text-opacity-50'>{lesson.title}</div>
+                ))}
+              </div>
+            </div>
+            <Link href={'#'}>
+              <Button text="Go to course details" buttonClass='rounded-md h-[28px] px-4 text-red text-xs font-[600] border border-red' />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </Fragment>
   );
 };
 

--- a/client/src/sections/learning-paths/ContentSection/index.tsx
+++ b/client/src/sections/learning-paths/ContentSection/index.tsx
@@ -1,6 +1,6 @@
 import Button from '@/src/shared/components/Button';
 import LearningPathCourseCard from '@/src/shared/components/Card/LearningPathCourseCard';
-import type { LearningPath } from '@/src/shared/utils';
+import type { Course, LearningPath } from '@/src/shared/utils';
 import Link from 'next/link';
 import React, { Fragment, useState, type FC } from 'react';
 
@@ -13,40 +13,60 @@ const LearningPathContentSection: FC<LearningPathContentSectionProp> = ({
 }): JSX.Element => {
   const [selectedCourse, setSelectedCourse] = useState(learningPath.courses[0] || null);
 
-  const handlePreview = (course) => {
-    console.log(course);
+  const handlePreview = (course: Course): void => {
     setSelectedCourse(course);
   };
   return (
     <Fragment>
       <div>
-        <h3 className='text-lg font-bold text-dark mb-2'>Description</h3>
-        <p className='text-sm font-normal text-dark'>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ipsum dolores error id, commodi ex et laborum, possimus voluptatum dolore facilis ullam eaque quae a eligendi asperiores placeat accusantium animi blanditiis? Eaque atque ex autem voluptates suscipit! Modi assumenda eum repudiandae nesciunt inventore dignissimos? Doloribus impedit voluptatem quidem assumenda, aspernatur ea.</p>
+        <h3 className="text-lg font-bold text-dark mb-2">Description</h3>
+        <p className="text-sm font-normal text-dark">
+          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ipsum dolores error id, commodi
+          ex et laborum, possimus voluptatum dolore facilis ullam eaque quae a eligendi asperiores
+          placeat accusantium animi blanditiis? Eaque atque ex autem voluptates suscipit! Modi
+          assumenda eum repudiandae nesciunt inventore dignissimos? Doloribus impedit voluptatem
+          quidem assumenda, aspernatur ea.
+        </p>
       </div>
-      <div className='flex gap-6 mt-4'>
-        <div className='grid gap-4'>
+      <div className="flex gap-6 mt-4">
+        <div className="grid gap-4">
           {learningPath?.courses.map((course, index) => (
             <div key={course.id} className="flex flex-col items-center">
-              <LearningPathCourseCard course={course} hasButton={true} isSelected={selectedCourse.id === course.id} onPreviewClick={() => { handlePreview(course); }} />
+              <LearningPathCourseCard
+                course={course}
+                hasButton={true}
+                isSelected={selectedCourse.id === course.id}
+                onPreviewClick={() => {
+                  handlePreview(course);
+                }}
+              />
             </div>
           ))}
         </div>
-        <div className='flex-1 gap-[10px]'>
-          <div className='grid gap-4 border border-neutral-900 p-4 rounded-md'>
+        <div className="flex-1 gap-[10px]">
+          <div className="grid gap-4 border border-neutral-900 p-4 rounded-md">
             <div>
-              <h3 className='text-base font-[600] text-dark mb-2'>{selectedCourse.name}</h3>
-              <p className='text-xs font-normal text-disabled'>{selectedCourse.description}</p>
+              <h3 className="text-base font-[600] text-dark mb-2">{selectedCourse.name}</h3>
+              <p className="text-xs font-normal text-disabled">{selectedCourse.description}</p>
             </div>
-            <div className='grid gap-1'>
-              <h3 className='text-sm font-[600] text-dark mb-2'>Course Overview</h3>
+            <div className="grid gap-1">
+              <h3 className="text-sm font-[600] text-dark mb-2">Course Overview</h3>
               <div>
                 {selectedCourse.lessons.map((lesson) => (
-                  <div key={lesson.id} className='bg-neutral-50 px-4 py-2 text-sm font-[500] text-lightGray3 text-opacity-50'>{lesson.title}</div>
+                  <div
+                    key={lesson.id}
+                    className="bg-neutral-50 px-4 py-2 text-sm font-[500] text-lightGray3 text-opacity-50"
+                  >
+                    {lesson.title}
+                  </div>
                 ))}
               </div>
             </div>
             <Link href={'#'}>
-              <Button text="Go to course details" buttonClass='rounded-md h-[28px] px-4 text-red text-xs font-[600] border border-red' />
+              <Button
+                text="Go to course details"
+                buttonClass="rounded-md h-[28px] px-4 text-red text-xs font-[600] border border-red"
+              />
             </Link>
           </div>
         </div>

--- a/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
+++ b/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
@@ -10,41 +10,59 @@ interface Props {
   isSelected?: boolean;
 }
 
-const LearningPathCourseCard = ({ course, hasButton, isSelected, onPreviewClick }: Props): JSX.Element => {
+const LearningPathCourseCard = ({
+  course,
+  hasButton,
+  isSelected,
+  onPreviewClick,
+}: Props): JSX.Element => {
   const lessonCount = course.lessons?.length ?? 0;
 
   const CourseContent = (): JSX.Element => {
     return (
-    <div className={`flex w-[420px] min-h-[128px] overflow-hidden bg-white border rounded-[5px] shadow-[2.0px_2.0px_4.0px_rgba(0,0,0,0.05)] ${isSelected ? 'border-neutral-900' : 'border-neutral-100'}`}>
-    <Image
-      src={course.image ?? '/image1.jpg'}
-      width={150}
-      height={150}
-      alt={course.name}
-      className="object-cover"
-    />
-    <div className="w-full relative p-4 flex flex-col gap-2">
-      <h3 className="line-clamp-2" title={course.name}>{course.name}</h3>
-      <div className="flex flex-col text-xs pb-2">
-        <span className="text-disabled">
-          {lessonCount} {lessonCount === 1 ? 'lesson' : 'lessons'} available
-        </span>
+      <div
+        className={`flex w-[420px] min-h-[128px] overflow-hidden bg-white border rounded-[5px] shadow-[2.0px_2.0px_4.0px_rgba(0,0,0,0.05)] ${
+          isSelected ? 'border-neutral-900' : 'border-neutral-100'
+        }`}
+      >
+        <Image
+          src={course.image ?? '/image1.jpg'}
+          width={150}
+          height={150}
+          alt={course.name}
+          className="object-cover"
+        />
+        <div className="w-full relative p-4 flex flex-col gap-2">
+          <h3 className="line-clamp-2" title={course.name}>
+            {course.name}
+          </h3>
+          <div className="flex flex-col text-xs pb-2">
+            <span className="text-disabled">
+              {lessonCount} {lessonCount === 1 ? 'lesson' : 'lessons'} available
+            </span>
+          </div>
+          {hasButton && (
+            <button
+              onClick={onPreviewClick}
+              className="w-[78px] h-[28px] rounded-md mt-2 text-xs font-[150] border border-dark"
+            >
+              Preview
+            </button>
+          )}
+        </div>
       </div>
-      {hasButton && <button onClick={onPreviewClick} className='w-[78px] h-[28px] rounded-md mt-2 text-xs font-[150] border border-dark'>Preview</button>}
-    </div>
-  </div>
     );
   };
 
   return (
     <Fragment>
-          {hasButton ? (
-            <CourseContent />
-          ) : (
-            <Link href={`/trainer/courses/${course.id}`}>
-              <CourseContent />
-            </Link>
-          )}
+      {hasButton ? (
+        <CourseContent />
+      ) : (
+        <Link href={`/trainer/courses/${course.id}`}>
+          <CourseContent />
+        </Link>
+      )}
     </Fragment>
   );
 };

--- a/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
+++ b/client/src/shared/components/Card/LearningPathCourseCard/index.tsx
@@ -1,33 +1,51 @@
 import type { Course } from '@/src/shared/utils';
 import Image from 'next/image';
 import Link from 'next/link';
+import React, { Fragment } from 'react';
 
 interface Props {
   course: Course;
+  hasButton?: boolean;
+  onPreviewClick?: () => void;
+  isSelected?: boolean;
 }
 
-const LearningPathCourseCard = ({ course }: Props): JSX.Element => {
+const LearningPathCourseCard = ({ course, hasButton, isSelected, onPreviewClick }: Props): JSX.Element => {
   const lessonCount = course.lessons?.length ?? 0;
-  return (
-    <Link href={`/trainer/courses/${course.id}`}>
-      <div className="flex w-[420px] min-h-[128px] overflow-hidden bg-white border rounded-[5px] border-neutral-100">
-        <Image
-          src={course.image ?? '/image1.jpg'}
-          width={150}
-          height={150}
-          alt={course.name}
-          className="object-cover"
-        />
-        <div className="w-full p-4 flex flex-col gap-2">
-          <h3 className="line-clamp-2" title={course.name}>{course.name}</h3>
-          <div className="flex flex-col text-xs">
-            <span className="text-disabled">
-              {lessonCount} {lessonCount === 1 ? 'lesson' : 'lessons'} available
-            </span>
-          </div>
-        </div>
+
+  const CourseContent = (): JSX.Element => {
+    return (
+    <div className={`flex w-[420px] min-h-[128px] overflow-hidden bg-white border rounded-[5px] shadow-[2.0px_2.0px_4.0px_rgba(0,0,0,0.05)] ${isSelected ? 'border-neutral-900' : 'border-neutral-100'}`}>
+    <Image
+      src={course.image ?? '/image1.jpg'}
+      width={150}
+      height={150}
+      alt={course.name}
+      className="object-cover"
+    />
+    <div className="w-full relative p-4 flex flex-col gap-2">
+      <h3 className="line-clamp-2" title={course.name}>{course.name}</h3>
+      <div className="flex flex-col text-xs pb-2">
+        <span className="text-disabled">
+          {lessonCount} {lessonCount === 1 ? 'lesson' : 'lessons'} available
+        </span>
       </div>
-    </Link>
+      {hasButton && <button onClick={onPreviewClick} className='w-[78px] h-[28px] rounded-md mt-2 text-xs font-[150] border border-dark'>Preview</button>}
+    </div>
+  </div>
+    );
+  };
+
+  return (
+    <Fragment>
+          {hasButton ? (
+            <CourseContent />
+          ) : (
+            <Link href={`/trainer/courses/${course.id}`}>
+              <CourseContent />
+            </Link>
+          )}
+    </Fragment>
   );
 };
 


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/LMS-701

## Defintion of Done

- [x] use the figma as reference
- [x] Preview button can be static for this task
- [x] Go to Course Details button can redirect to "#"

## Steps to reproduce
redirect to: http://localhost:3000/trainer/learning-paths/2

## Affected Components / Functionalities / Page
client/src/sections/learning-paths/ContentSection/index.tsx
client/src/shared/components/Card/LearningPathCourseCard/index.tsx


## Notes
Since we have replaced the design Learning path data is already integrated. I only edited some of the UI changes.

## Screenshots
![image](https://github.com/framgia/sph-lms/assets/110363852/7eb6ee8a-50c4-4fc9-9c6d-a3ee4346eac2)
