### PR TITLE
[LMS-707][MARKUP] Course & Learning Path List Page

### DIFF
--- a/client/src/pages/trainer/courses/index.tsx
+++ b/client/src/pages/trainer/courses/index.tsx
@@ -59,6 +59,7 @@ const CoursesListPage: React.FC = () => {
     setPage(page);
   };
 
+  const hasCourses = courses.length > 0;
   return (
     <Fragment>
       <Head>
@@ -67,12 +68,19 @@ const CoursesListPage: React.FC = () => {
       <div>
         <div className="flex justify-center">
           <div className="container mt-4 w-fit">
-            <div className="flex justify-between gap-4 items-center mb-4">
-              <SearchBar
-                onSearchEvent={handleSearch}
-                placeholder="Search"
-                searchClass="sm:w-[24rem] md:w-[350px] md:lg-[400px] sm:h-[40px]"
-              />
+            <div
+              className={`flex  ${
+                hasCourses || search ? 'justify-between' : 'justify-end'
+              } gap-4 items-center mb-4`}
+            >
+              {(hasCourses || search) && (
+                <SearchBar
+                  onSearchEvent={handleSearch}
+                  placeholder="Search"
+                  searchClass="sm:w-[24rem] md:w-[350px] md:lg-[400px] sm:h-[40px]"
+                />
+              )}
+
               <Link
                 href="/trainer/courses/create"
                 className="border border-red text-red text-sm h-9 items-center rounded-md font-medium px-4 py-2"
@@ -80,7 +88,7 @@ const CoursesListPage: React.FC = () => {
                 Create a course
               </Link>
             </div>
-            <div className="flex justify-center mb-4">
+            <div className="flex w-[1120px] justify-center mb-4">
               {/* eslint-disable-next-line multiline-ternary */}
               {!courses.length ? (
                 <div className="flex items-center text-sm text-gray-400 h-24">

--- a/client/src/pages/trainer/learning-paths/index.tsx
+++ b/client/src/pages/trainer/learning-paths/index.tsx
@@ -1,13 +1,19 @@
+import { type TabState } from '@/src/features/tab/tabSlice';
 import LearningPathList from '@/src/sections/learning-paths';
+import { useGetLearningPathsQuery } from '@/src/services/learningPathAPI';
 import SearchBar from '@/src/shared/components/SearchBar/SearchBar';
 import Tabs from '@/src/shared/components/Tabs';
 import Tab from '@/src/shared/components/Tabs/Tab';
+import { type RootState } from '@reduxjs/toolkit/dist/query/core/apiState';
 import Link from 'next/link';
 import { Fragment, useEffect, useState } from 'react';
 import { reset as resetLearningPath } from '@/src/features/learning-path/learningPathSlice';
 import { useAppDispatch } from '@/src/redux/hooks';
+import { useSelector } from 'react-redux';
 
 const LearningPathListPage: React.FC = () => {
+  const { data: activeData } = useGetLearningPathsQuery({ page: 1, isActive: true });
+  const { data: inactiveData } = useGetLearningPathsQuery({ page: 1, isActive: false });
   const [search, setSearch] = useState('');
   const [activePage, setActivePage] = useState(1);
   const [inactivePage, setInactivePage] = useState(1);
@@ -16,6 +22,7 @@ const LearningPathListPage: React.FC = () => {
   useEffect(() => {
     dispatch(resetLearningPath());
   });
+  const activeTab = useSelector<RootState, TabState['activeTab']>((state) => state.tab.activeTab);
 
   const handleSearch = (search: string): void => {
     setSearch(search);
@@ -36,12 +43,23 @@ const LearningPathListPage: React.FC = () => {
     );
   };
 
+  const hasActiveData = activeData?.results?.length > 0;
+  const hasInActiveData = inactiveData?.results?.length > 0;
+
   return (
     <Fragment>
       <div className="flex flex-col justify-center items-center gap-4 w-full pt-4">
         <div className="flex flex-col gap-4 container">
-          <div className="flex justify-between items-center md:mx-28 lg:mx-24 xl:52 2xl:mx-[13.5rem]">
-            <SearchBar onSearchEvent={handleSearch} placeholder="Search" />
+          <div
+            className={`flex ${
+              (activeTab === 0 && hasActiveData) || (activeTab === 1 && hasInActiveData)
+                ? 'justify-between'
+                : 'justify-end'
+            } items-center md:mx-28 lg:mx-24 xl:52 2xl:mx-[13.5rem]`}
+          >
+            {(activeTab === 0 && hasActiveData) || (activeTab === 1 && hasInActiveData) ? (
+              <SearchBar onSearchEvent={handleSearch} placeholder="Search" />
+            ) : null}
             <Link
               href="/trainer/learning-paths/create"
               className="border border-red text-red text-sm h-9 items-center rounded-md font-medium px-4 py-2"


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/LMS-707

## Defintion of Done

- [x] Fix Course List Page alignment if no course is available
- [x] [Course & Learning Path] hide Search Bar if no item at all

## Steps to reproduce
Redirect to:
Courses tab: http://localhost:3000/trainer/courses
Learning Path tab: http://localhost:3000/trainer/learning-paths
Click active and inactive, with and without learning path data.

## Affected Components / Functionalities / Page
client/src/pages/trainer/courses/index.tsx
client/src/pages/trainer/learning-paths/index.tsx
client/src/shared/components/Tabs/Tab.tsx


## Screenshots
[lms-707.webm](https://github.com/framgia/sph-lms/assets/110363852/6fdcd123-7c02-4915-b6ad-85b4708b596d)
