### PR TITLE
LMS-708 [MARKUP] Fix State for Stepper and Create of Course and learn…

### DIFF
--- a/client/src/pages/trainer/courses/index.tsx
+++ b/client/src/pages/trainer/courses/index.tsx
@@ -9,17 +9,24 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React, { Fragment, useEffect, useState } from 'react';
 import CourseCard from '../../../shared/components/Card/CourseCard';
+import { reset as resetCourse } from '@/src/features/course/courseSlice';
+import { useAppDispatch } from '@/src/redux/hooks';
 
 const CoursesListPage: React.FC = () => {
   const router = useRouter();
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
+  const dispatch = useAppDispatch();
 
   const {
     data: { results: courses = [], totalPages, current_page_number: currentPage } = {},
     isLoading,
     error,
   } = useGetCoursesQuery({ search, page, pageSize: 12 });
+
+  useEffect(() => {
+    dispatch(resetCourse());
+  });
 
   useEffect(() => {
     if (search === '') {

--- a/client/src/pages/trainer/learning-paths/index.tsx
+++ b/client/src/pages/trainer/learning-paths/index.tsx
@@ -3,12 +3,19 @@ import SearchBar from '@/src/shared/components/SearchBar/SearchBar';
 import Tabs from '@/src/shared/components/Tabs';
 import Tab from '@/src/shared/components/Tabs/Tab';
 import Link from 'next/link';
-import { Fragment, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
+import { reset as resetLearningPath } from '@/src/features/learning-path/learningPathSlice';
+import { useAppDispatch } from '@/src/redux/hooks';
 
 const LearningPathListPage: React.FC = () => {
   const [search, setSearch] = useState('');
   const [activePage, setActivePage] = useState(1);
   const [inactivePage, setInactivePage] = useState(1);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(resetLearningPath());
+  });
 
   const handleSearch = (search: string): void => {
     setSearch(search);

--- a/client/src/shared/components/Stepper/index.tsx
+++ b/client/src/shared/components/Stepper/index.tsx
@@ -19,6 +19,7 @@ const Stepper: FC<StepperProps> = ({ title, contentClass = '', onNext, children 
   const dispatch = useAppDispatch();
   const [childrenList, setChildrenList] = useState<ChildElementObject>({});
   const childListLength = Object.keys(childrenList).length;
+  const [isMounted, setIsMounted] = useState(true);
 
   const handleNext = async (): Promise<void> => {
     let validated = true;
@@ -40,6 +41,11 @@ const Stepper: FC<StepperProps> = ({ title, contentClass = '', onNext, children 
   };
 
   useEffect(() => {
+    if (isMounted) {
+      dispatch(reset());
+      setIsMounted(false);
+    }
+
     let step = 0;
     const childrenListObj: ChildElementObject = {};
     Children.map(children, (child) => {


### PR DESCRIPTION
…ing Path

## Issue Link
[LMS-708 [MARKUP] Fix State for Stepper and Create of Course and learning Path
](https://framgiaph.backlog.com/view/LMS-708)

## Defintion of Done
reset the step state when visiting course or learning path create (should always start with step 1)
reset the input fields when visiting course or learning path create

## Steps to reproduce
- go to http://localhost:3000/trainer/courses/create
- fill the input fields until step 3 (dont click create on step 3)
- go to http://localhost:3000/trainer/learning-paths/create
- it should start to Step 1
- go back to http://localhost:3000/trainer/courses/create 
- input fields should be empty
- vice versa

## Affected Components / Functionalities / Page
- client/src/pages/trainer/courses/index.tsx
- client/src/pages/trainer/learning-paths/index.tsx
- client/src/shared/components/Stepper/index.tsx

## Test Cases
_will update soon..._

## Notes
n/a

## Screenshots
![State Fix](https://github.com/framgia/sph-lms/assets/115448429/1bf2f250-5135-4127-9b05-f2ff387b42a8)
