### PR TITLE
[LMS-711][MARKUP] Create Training Page

### DIFF
--- a/client/src/pages/trainee/course/[id]/training/index.tsx
+++ b/client/src/pages/trainee/course/[id]/training/index.tsx
@@ -1,0 +1,79 @@
+/* eslint-disable multiline-ternary */
+import React, { Fragment } from 'react';
+import Container from '@/src/shared/layouts/Container';
+import Breadcrumbs from '@/src/shared/components/Breadcrumbs';
+import SidebarContent from '@/src/shared/components/SidebarContent';
+import SideBar from '@/src/shared/components/SidebarContent/SideBar';
+import Iframe from '@/src/shared/components/Iframe';
+
+const TrainingPage: React.FunctionComponent = () => {
+  const paths = [
+    {
+      text: 'My Course',
+      url: '/trainer/courses',
+    },
+    {
+      text: 'Course Title',
+      url: '/trainee/course/1/training',
+    },
+  ];
+  return (
+    <Fragment>
+      <Container>
+        <div className="ml-5 mt-5">
+          <Breadcrumbs paths={paths} />
+          <div className="flex flex-grow h-full mt-5">
+            <SidebarContent isCheckbox={true}>
+              <SideBar title="Section 1">
+                <div className="ml-7">
+                  <div className="text-[20px] font-semibold text-textGray">Section 1</div>
+                  <div className="py-3">
+                    <Iframe
+                      src="https://www.youtube.com/embed/cJveiktaOSQ"
+                      className="w-[946px] h-[554px]"
+                    />
+                  </div>
+                </div>
+              </SideBar>
+              <SideBar title="Section 2">
+                <div className="ml-7 flex-grow ">
+                  <div className="text-[20px] font-semibold text-textGray">Section 2</div>
+                  <div className="py-3">
+                    <Iframe
+                      src="https://www.youtube.com/embed/HGl75kurxok"
+                      className="w-[946px] h-[554px]"
+                    />
+                  </div>
+                </div>
+              </SideBar>
+              <SideBar title="Section 3">
+                <div className="ml-7 flex-grow ">
+                  <div className="text-[20px] font-semibold text-textGray">Section 3</div>
+                  <div className="py-3">
+                    <Iframe
+                      src="https://www.youtube.com/embed/Zy0y_gnyeJY"
+                      className="w-[946px] h-[554px]"
+                    />
+                  </div>
+                </div>
+              </SideBar>
+              <SideBar title="Section 4">
+                <div className="ml-7 flex-grow ">
+                  <div className="text-[20px] font-semibold text-textGray">Section 4</div>
+                  <div className="py-3">
+                    <Iframe
+                      src="https://www.youtube.com/embed/d56mG7DezGs"
+                      className="w-[946px] h-[554px]"
+                    />
+                  </div>
+                </div>
+              </SideBar>
+            </SidebarContent>
+          </div>
+        </div>
+      </Container>
+    </Fragment>
+  );
+};
+
+export default TrainingPage;

--- a/client/src/sections/courses/ContentSection.tsx
+++ b/client/src/sections/courses/ContentSection.tsx
@@ -16,7 +16,7 @@ const ContentSection: React.FunctionComponent<CourseData> = ({ course }: CourseD
             {course?.lessons?.map((col) => (
               <SideBar title={col.title} key={col.id}>
                 <div className="ml-7">
-                  <div className="text-20 font-semibold text-textGray">{col.title}</div>
+                  <div className="text-[20px] font-semibold text-textGray">{col.title}</div>
                   <div className="py-3">
                     {isYoutubeLink(col.link) ? (
                       <Iframe src={col.link} className="w-[946px] h-[554px]" />

--- a/client/src/shared/components/SidebarContent/index.tsx
+++ b/client/src/shared/components/SidebarContent/index.tsx
@@ -5,9 +5,10 @@ import { type SideBarProps } from './SideBar';
 
 interface SidebarContentProps {
   children: ReactElement<SideBarProps> | Array<ReactElement<SideBarProps>>;
+  isCheckbox?: boolean;
 }
 
-const SidebarContent: FC<SidebarContentProps> = ({ children }) => {
+const SidebarContent: FC<SidebarContentProps> = ({ children, isCheckbox = false }) => {
   const [activeTab, setActiveTab] = useState<null | number>(null);
   const [childrenList, setChildrenList] = useState<ChildElementObject>({});
 
@@ -48,6 +49,15 @@ const SidebarContent: FC<SidebarContentProps> = ({ children }) => {
                 setActiveTab(id);
               }}
             >
+              {isCheckbox && (
+                <input
+                  type="checkbox"
+                  className="mr-2 accent-black cursor-pointer"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                />
+              )}
               {title}
             </div>
           ))}


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/board/LMS?selectedIssueKey=LMS-711&assignee=417519

## Defintion of Done
create training page
2 sections, left section list down the lessons and its status (checkbox), right section shows content. (Use same implementation used in trainer's course content tab)
selecting lessons should update content

## Steps to reproduce
docker-compose up
visit url: http://localhost:3000/trainee/course/1/training

## Affected Components / Functionalities / Page
sidebarContent Component
training page

## Test Cases
test markup for training page
Checkbox should be functioning
should not set to active tab when checkbox is clicked

## Notes
Implemented same design to trainer's course content page

## Screenshots
![image](https://github.com/framgia/sph-lms/assets/110363969/2ab9d4ab-6110-4955-89ea-36d7bfac2154)
