### PR TITLE
LMS-714 [MARKUP/INTEGRATION] Trainee Learning Path Page

### DIFF
--- a/client/src/pages/trainee/course/[id]/index.tsx
+++ b/client/src/pages/trainee/course/[id]/index.tsx
@@ -24,7 +24,7 @@ const TraineeCoursePage: FC = () => {
 
   const paths = [
     {
-      text: 'My Courses',
+      text: 'Dashboard',
       url: '/trainee/dashboard',
     },
     {
@@ -41,7 +41,12 @@ const TraineeCoursePage: FC = () => {
       <Container>
         <div className="grid gap-4 relative mt-5 lg:mx-32 mb-5 cursor-default">
           <div className="relative bg-slate-800 w-full h-[210px]">
-            <Image src={course?.image} alt={course?.name} fill style={{ objectFit: 'cover' }} />
+            <Image
+              src={course?.image ? course?.image : '/image1.jpg'}
+              alt={course?.name}
+              fill
+              style={{ objectFit: 'cover' }}
+            />
           </div>
           <div className="">
             <h1 className="text-lg font-bold text-dark pb-1">{course?.name}</h1>

--- a/client/src/pages/trainee/learning-path/[id]/index.tsx
+++ b/client/src/pages/trainee/learning-path/[id]/index.tsx
@@ -1,0 +1,51 @@
+import React, { Fragment } from 'react';
+import Container from '@/src/shared/layouts/Container';
+import Breadcrumbs from '@/src/shared/components/Breadcrumbs';
+import { useRouter } from 'next/router';
+import { useGetLearningPathQuery } from '@/src/services/traineeAPI';
+import LearningPathContentSection from '@/src/sections/learning-paths/ContentSection';
+import Spinner from '@/src/shared/components/Spinner';
+import { alertError } from '@/src/shared/utils';
+
+const TraineeLearningPath: React.FunctionComponent = () => {
+  const { query } = useRouter();
+
+  const {
+    data: learningPath,
+    isLoading,
+    error,
+  } = useGetLearningPathQuery(query.id, {
+    skip: query.id === undefined,
+  });
+
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  if (error) {
+    return alertError('An error occured');
+  }
+
+  const paths = [
+    {
+      text: 'Dashboard',
+      url: '/trainee/dashboard',
+    },
+    {
+      text: 'Learning Path Name',
+      url: `/trainee/learning-path/${learningPath?.id}`,
+    },
+  ];
+  return (
+    <Fragment>
+      <div className="ml-5 mt-5">
+        <Breadcrumbs paths={paths} />
+      </div>
+      <Container>
+        <LearningPathContentSection learningPath={learningPath} />
+      </Container>
+    </Fragment>
+  );
+};
+
+export default TraineeLearningPath;

--- a/client/src/sections/learning-paths/ContentSection/index.tsx
+++ b/client/src/sections/learning-paths/ContentSection/index.tsx
@@ -1,6 +1,7 @@
 import Button from '@/src/shared/components/Button';
 import LearningPathCourseCard from '@/src/shared/components/Card/LearningPathCourseCard';
 import type { Course, LearningPath } from '@/src/shared/utils';
+import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import React, { Fragment, useState, type FC } from 'react';
 
@@ -11,6 +12,9 @@ interface LearningPathContentSectionProp {
 const LearningPathContentSection: FC<LearningPathContentSectionProp> = ({
   learningPath,
 }): JSX.Element => {
+  const { data: session } = useSession();
+  const isTrainer = session?.user.is_trainer;
+
   const [selectedCourse, setSelectedCourse] = useState(learningPath.courses[0] || null);
 
   const handlePreview = (course: Course): void => {
@@ -56,12 +60,27 @@ const LearningPathContentSection: FC<LearningPathContentSectionProp> = ({
                       key={lesson.id}
                       className="bg-neutral-50 px-4 py-2 text-sm font-[500] text-lightGray3 text-opacity-50"
                     >
+                      {!isTrainer && (
+                        <input
+                          type="checkbox"
+                          disabled
+                          checked={lesson?.is_completed}
+                          className="accent-checkbox mr-5"
+                        />
+                      )}
+
                       {lesson.title}
                     </div>
                   ))}
                 </div>
               </div>
-              <Link href={`/trainer/courses/${selectedCourse.id}`}>
+              <Link
+                href={
+                  isTrainer
+                    ? `/trainer/courses/${selectedCourse.id}`
+                    : `/trainee/course/${selectedCourse.id}`
+                }
+              >
                 <Button
                   text="Go to course details"
                   buttonClass="rounded-md px-4 py-2 text-red text-xs font-[600] border border-red"

--- a/client/src/services/traineeAPI.ts
+++ b/client/src/services/traineeAPI.ts
@@ -13,7 +13,13 @@ export const getCourseTrainee = createApi({
       return headers;
     },
   }),
-  tagTypes: ['CourseTrainee', 'LearningPathTrainee', 'TrainerTrainee', 'TraineeCourses'],
+  tagTypes: [
+    'CourseTrainee',
+    'LearningPathTrainee',
+    'TrainerTrainee',
+    'TraineeCourses',
+    'LearningPathDetails',
+  ],
   endpoints: (builder) => ({
     getLearner: builder.query({
       query: ({ courseId, isEnrolled, searchQuery, pageNumber, selectedSortOption }) => ({
@@ -94,20 +100,24 @@ export const getCourseTrainee = createApi({
       }),
       invalidatesTags: ['LearningPathTrainee', 'TrainerTrainee'],
     }),
+    getLearningPath: builder.query({
+      query: (id) => `learning-paths/${id}`,
+      providesTags: ['LearningPathDetails'],
+    }),
     addCompletedLesson: builder.mutation({
       query: (formData) => ({
         url: 'trainee/completed-lesson',
         method: 'POST',
         body: formData,
       }),
-      invalidatesTags: ['TraineeCourses'],
+      invalidatesTags: ['TraineeCourses', 'LearningPathDetails'],
     }),
     removeCompletedLesson: builder.mutation({
       query: (lessonID) => ({
         url: `trainee/completed-lesson/${lessonID}`,
         method: 'DELETE',
       }),
-      invalidatesTags: ['TraineeCourses'],
+      invalidatesTags: ['TraineeCourses', 'LearningPathDetails'],
     }),
   }),
 });
@@ -120,6 +130,7 @@ export const {
   useGetTraineeCourseQuery,
   useEnrollLearnerMutation,
   useEnrollLearningPathLearnerMutation,
+  useGetLearningPathQuery,
   useAddCompletedLessonMutation,
   useRemoveCompletedLessonMutation,
 } = getCourseTrainee;

--- a/client/src/shared/components/Card/LearningPathCard/index.tsx
+++ b/client/src/shared/components/Card/LearningPathCard/index.tsx
@@ -13,7 +13,7 @@ const LearningPathCard: React.FC<Props> = ({ learningPath, isTrainee = false }: 
 
   return (
     <div className="w-[268px] rounded-md border shadow-[2px_2px_4px_0_rgba(0, 0, 0, 0.05)]">
-      <Link href={isTrainee ? '#' : `/trainer/learning-paths/${id}`}>
+      <Link href={isTrainee ? `/trainee/learning-path/${id}` : `/trainer/learning-paths/${id}`}>
         <div className="relative overflow-hidden group">
           <Image
             className="w-full h-32 rounded-tl-md rounded-tr-md object-cover transition-transform duration-300 group-hover:scale-110 cursor-pointer"


### PR DESCRIPTION
## Issue Link
[LMS-714 [MARKUP/INTEGRATION] Trainee Learning Path Page](https://framgiaph.backlog.com/view/LMS-714)

## Defintion of Done
- reuse the existing Learning path page sections in trainers side
- make sure that the go to course button redirects to tranee's url path (update the redirect depends on role)
- for course content details, under course overview, the lessons should display the status (checkbox)

## Steps to reproduce
- in dashboard, toggle to `My Leaning Path` and click enrolled learning path ( for testing purposes you can add manually in django admin panel)

## Affected Components / Functionalities / Page
- client/src/pages/trainee/course/[id]/index.tsx
- client/src/sections/learning-paths/ContentSection/index.tsx
- client/src/services/traineeAPI.ts
- client/src/shared/components/Card/LearningPathCard/index.tsx

## Test Cases
_will update soon..._

## Notes
n/a

## Screenshots
![chrome_SyGJVqTocZ](https://github.com/framgia/sph-lms/assets/115448429/ec4dd9ab-de8d-4872-889f-2e29897ebc61)
