### PR TITLE
LMS-716 Fix Index Page Redirection

### DIFF
--- a/api/app_sph_lms/signals.py
+++ b/api/app_sph_lms/signals.py
@@ -7,5 +7,6 @@ from django.dispatch import receiver
 @receiver(post_save, sender=SocialAccount)
 def set_default_password(sender, instance, created, **kwargs):
     if created and instance.provider == 'google':
+        instance.user.username = instance.user.email
         instance.user.password = make_password("password")
         instance.user.save()

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,11 +1,31 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import Head from 'next/head';
 import NavbarSection from '../sections/landing-page/NavbarSection';
 import HeroSection from '../sections/landing-page/HeroSection';
 import BenefitSection from '../sections/landing-page/BenefitSection';
 import TestimonialSection from '../sections/landing-page/TestimonialSection';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
+import Spinner from '../shared/components/Spinner';
 
 const LandingPage: React.FunctionComponent = () => {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (session) {
+      const route = session.user.is_trainer ? '/trainer/dashboard' : '/trainee/dashboard';
+      void router.push(route);
+    } else {
+      setLoading(false);
+    }
+  }, [session, router]);
+
+  if (loading) {
+    return <Spinner />;
+  }
+
   return (
     <Fragment>
       <Head>
@@ -14,9 +34,7 @@ const LandingPage: React.FunctionComponent = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <div className="sticky top-0 overflow-hidden">
-        <NavbarSection
-          navItems={['About', 'Benefits', 'Testimonies']}
-        ></NavbarSection>
+        <NavbarSection navItems={['About', 'Benefits', 'Testimonies']}></NavbarSection>
       </div>
       <div className="h-screen w-auto pl-40 pr-10">
         <HeroSection></HeroSection>


### PR DESCRIPTION
## Issue Link
[LMS-716 Fix Index Page Redirection](https://framgiaph.backlog.com/view/LMS-716)

## Defintion of Done
- index page redirects to user's dashboard

## Steps to reproduce
- visit http://localhost:3000
- you will be redirected to user's dashboard or sign in page

## Affected Components / Functionalities / Page
- api/app_sph_lms/signals.py
- client/src/pages/index.tsx

## Test Cases
_will update soon..._

## Notes
- I also included minimal additional settings for signals.py

## Screenshots
![chrome_aw6PX7ZvvD](https://github.com/framgia/sph-lms/assets/115448429/ee33fded-2d86-4d32-ac23-bbd5489dad5c)
